### PR TITLE
算額の写し作成,一覧機能

### DIFF
--- a/app/lib/actions/shrine.ts
+++ b/app/lib/actions/shrine.ts
@@ -53,3 +53,47 @@ export async function dedicateSangaku(
     await setFlash({ type: "error", message: "予期せぬエラーが発生しました" });
   }
 }
+
+export async function createSangakuSave(sangaku_id: string) {
+  const session = await auth();
+  if (!session) {
+    setFlash({ type: "error", message: "サインインしてください" });
+    return null;
+  }
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${session?.accessToken}`,
+  };
+
+  try {
+    const res = await fetch(`${apiUrl}/api/v1/sangakus/${sangaku_id}/save`, {
+      method: "POST",
+      headers,
+    });
+
+    switch (res.status) {
+      case 200:
+        await setFlash({
+          type: "success",
+          message: "算額の写しを作成しました",
+        });
+        // revalidatePath("/user/saved_sangakus");
+        break;
+      case 401:
+        await setFlash({
+          type: "error",
+          message:
+            "セッションの有効期限が切れています。\n再度ログインしてください",
+        });
+        await signOut({ redirectTo: "/signin" });
+        break;
+      default:
+        await setFlash({ type: "error", message: "リクエストに失敗しました" });
+    }
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    }
+    await setFlash({ type: "error", message: "予期せぬエラーが発生しました" });
+  }
+}

--- a/app/lib/data/sangaku.ts
+++ b/app/lib/data/sangaku.ts
@@ -128,3 +128,43 @@ export async function fetchShrineSangakus(
     };
   }
 }
+
+export async function fetchSavedSangakus(
+  page: string,
+  query: string,
+  difficulty: string,
+): Promise<{ sangakus: Sangaku[]; totalPage: number; message?: string }> {
+  const session = await auth();
+
+  try {
+    const headers: HeadersInit = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${session?.accessToken}`,
+    };
+
+    const params = new URLSearchParams({ page, title: query, difficulty });
+
+    const res = await fetch(`${apiUrl}/api/v1/user/sangaku_saves?${params}`, {
+      headers,
+    });
+
+    if (res.status === 200) {
+      const data = await res.json();
+      const sangakus = data.data as Sangaku[];
+      const totalPage = parseInt(res.headers.get("total-pages")!);
+      return { sangakus, totalPage };
+    } else {
+      return {
+        sangakus: [] as Sangaku[],
+        totalPage: 0,
+        message: "リクエストに失敗しました",
+      };
+    }
+  } catch {
+    return {
+      sangakus: [] as Sangaku[],
+      totalPage: 0,
+      message: "予期せぬエラーが発生しました",
+    };
+  }
+}

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -7,6 +7,7 @@ export type Sangaku = {
     source: string;
     difficulty: Difficulty;
     inputs: input[];
+    author_name: string;
   };
   relationships: {
     user: {

--- a/app/shrines/[id]/sangakus/page.tsx
+++ b/app/shrines/[id]/sangakus/page.tsx
@@ -4,7 +4,7 @@ import Box from "@mui/material/Box";
 import { notFound } from "next/navigation";
 import SangakuList from "@/app/ui/shrine/sangakus/SangakuList";
 import { Suspense } from "react";
-import { ShrineSangakuListSkeleton } from "@/app/ui/skeletons";
+import { SangakuWithButtonListSkeleton } from "@/app/ui/skeletons";
 import Search from "@/app/ui/Search";
 
 interface Props {
@@ -35,7 +35,7 @@ export default async function Page(props: Props) {
       </Container>
       <Suspense
         key={page + query + difficulty}
-        fallback={<ShrineSangakuListSkeleton />}
+        fallback={<SangakuWithButtonListSkeleton width={102} />}
       >
         <SangakuList
           shrine_id={id}

--- a/app/solve/page.tsx
+++ b/app/solve/page.tsx
@@ -1,0 +1,33 @@
+import { Suspense } from "react";
+import { SangakuWithButtonListSkeleton } from "@/app/ui/skeletons";
+import SavedSangakuList from "@/app/ui/solve/SavedSangakuList";
+import { Box, Container, Typography } from "@mui/material";
+import Search from "@/app/ui/Search";
+
+interface Props {
+  searchParams: Promise<{ page: string; query: string; difficulty: string }>;
+}
+
+export default async function Page(props: Props) {
+  const searchParams = await props.searchParams;
+  const page = searchParams.page || "1";
+  const query = searchParams.query || "";
+  const difficulty = searchParams.difficulty || "";
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 6 }}>
+        算額を解く
+      </Typography>
+      <Container maxWidth="md">
+        <Search placeholder="タイトルで探す" difficulty />
+      </Container>
+      <Suspense
+        key={page + query + difficulty}
+        fallback={<SangakuWithButtonListSkeleton width={102} />}
+      >
+        <SavedSangakuList page={page} query={query} difficulty={difficulty} />
+      </Suspense>
+    </Box>
+  );
+}

--- a/app/ui/navigation/Drawer.tsx
+++ b/app/ui/navigation/Drawer.tsx
@@ -14,7 +14,7 @@ import NextLink from "next/link";
 const drawerContent = [
   { text: "神社を探す", href: "/shrines" },
   { text: "算額を作る", href: "/sangakus/create" },
-  { text: "算額を解く", href: "#" },
+  { text: "算額を解く", href: "/solve" },
   { text: "自分の算額を見る", href: "/user/sangakus" },
 ];
 

--- a/app/ui/shrine/sangakus/Sangaku.tsx
+++ b/app/ui/shrine/sangakus/Sangaku.tsx
@@ -1,8 +1,9 @@
 import type { Sangaku } from "@/app/lib/definitions";
 import Grid from "@mui/material/Grid2";
 import Ema from "@/app/ui/Ema";
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { difficultyTranslation } from "@/app/ui/utility";
+import { SangakuSaveButton } from "./buttons";
 
 interface Props {
   sangaku: Sangaku;
@@ -58,7 +59,7 @@ export default function Sangaku({ sangaku }: Props) {
         </Box>
       </Ema>
       <Box sx={{ display: "flex", justifyContent: "end", mt: 1 }}>
-        <Button variant="contained">算額を写す</Button>
+        <SangakuSaveButton id={sangaku.id} />
       </Box>
     </Grid>
   );

--- a/app/ui/shrine/sangakus/buttons.tsx
+++ b/app/ui/shrine/sangakus/buttons.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { createSangakuSave } from "@/app/lib/actions/shrine";
+import { Button } from "@mui/material";
+
+interface Props {
+  id: string;
+}
+
+export function SangakuSaveButton({ id }: Props) {
+  return (
+    <Button
+      variant="contained"
+      onClick={() => {
+        createSangakuSave(id);
+      }}
+    >
+      算額を写す
+    </Button>
+  );
+}

--- a/app/ui/skeletons.tsx
+++ b/app/ui/skeletons.tsx
@@ -38,7 +38,11 @@ export function SangakuListSkeleton() {
   );
 }
 
-export function ShrineSangakuListSkeleton() {
+export function SangakuWithButtonListSkeleton({
+  width,
+}: {
+  width: string | number;
+}) {
   return (
     <Grid2
       container
@@ -73,7 +77,7 @@ export function ShrineSangakuListSkeleton() {
           <Box sx={{ display: "flex", justifyContent: "end", mt: 1 }}>
             <Skeleton
               variant="rectangular"
-              width={102}
+              width={width}
               height={36.5}
               sx={{ borderRadius: 1 }}
             />

--- a/app/ui/solve/SavedSangaku.tsx
+++ b/app/ui/solve/SavedSangaku.tsx
@@ -1,0 +1,82 @@
+import { Sangaku } from "@/app/lib/definitions";
+import Ema from "@/app/ui/Ema";
+import Grid from "@mui/material/Grid2";
+import { Box, Button, Typography } from "@mui/material";
+import { difficultyTranslation } from "../utility";
+import Link from "next/link";
+
+interface Props {
+  sangaku: Sangaku;
+}
+
+export default function SavedSangaku({ sangaku }: Props) {
+  return (
+    <Grid key={sangaku.id}>
+      <Ema width={18}>
+        <Box
+          sx={{
+            display: "flex",
+            height: "100%",
+            flexDirection: "column",
+            justifyContent: "start",
+          }}
+        >
+          <Typography
+            variant="h5"
+            sx={{
+              mb: 1,
+              textAlign: "center",
+              overflow: "hidden",
+              display: "-webkit-box",
+              WebkitLineClamp: 1,
+              WebkitBoxOrient: "vertical",
+              textOverflow: "ellipsis",
+              whiteSpace: "pre-line",
+            }}
+          >
+            {sangaku.attributes.title}
+          </Typography>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              marginTop: "auto",
+            }}
+          >
+            <Typography
+              sx={{
+                textAlign: "center",
+                overflow: "hidden",
+                display: "-webkit-box",
+                WebkitLineClamp: 1,
+                WebkitBoxOrient: "vertical",
+                textOverflow: "ellipsis",
+                whiteSpace: "pre-line",
+                alignContent: "center",
+              }}
+            >
+              {sangaku.attributes.author_name}
+            </Typography>
+            <Typography
+              component="p"
+              sx={{
+                px: 1,
+                py: 0.5,
+                border: 1,
+                borderRadius: 2,
+                textAlign: "right",
+              }}
+            >
+              {difficultyTranslation(sangaku.attributes.difficulty)}
+            </Typography>
+          </Box>
+        </Box>
+      </Ema>
+      <Box sx={{ display: "flex", justifyContent: "end", mt: 1 }}>
+        <Button variant="contained" href="#" LinkComponent={Link}>
+          算額を解く
+        </Button>
+      </Box>
+    </Grid>
+  );
+}

--- a/app/ui/solve/SavedSangakuList.tsx
+++ b/app/ui/solve/SavedSangakuList.tsx
@@ -1,0 +1,51 @@
+import Grid from "@mui/material/Grid2";
+import { Box, Typography } from "@mui/material";
+import { fetchSavedSangakus } from "@/app/lib/data/sangaku";
+import Pagination from "../Pagination";
+import SavedSangaku from "./SavedSangaku";
+
+interface Props {
+  page: string;
+  query: string;
+  difficulty: string;
+}
+
+export default async function SavedSangakuList({
+  page,
+  query,
+  difficulty,
+}: Props) {
+  const { sangakus, totalPage, message } = await fetchSavedSangakus(
+    page,
+    query,
+    difficulty,
+  );
+
+  return (
+    <Box>
+      {message && (
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <Typography sx={{ color: "red", mt: 2 }}>{message}</Typography>
+        </Box>
+      )}
+      <Grid
+        container
+        direction="row"
+        spacing={3}
+        sx={{
+          justifyContent: "center",
+          alignItems: "flex-start",
+          mt: 3,
+          mb: 2,
+        }}
+      >
+        {sangakus.map((sangaku) => (
+          <SavedSangaku sangaku={sangaku} key={sangaku.id} />
+        ))}
+      </Grid>
+      <Box sx={{ display: "flex", justifyContent: "center" }}>
+        <Pagination totalPage={totalPage} />
+      </Box>
+    </Box>
+  );
+}

--- a/tests/components/navigation/Drawer.spec.tsx
+++ b/tests/components/navigation/Drawer.spec.tsx
@@ -159,7 +159,7 @@ test.describe("Drawer", () => {
       );
       const link = component.getByRole("link", { name: "算額を解く" });
       await expect(link).toBeVisible();
-      await expect(link).toHaveAttribute("href", "#");
+      await expect(link).toHaveAttribute("href", "/solve");
     });
 
     test("has link to ShowOwnSangaku page", async ({ mount }) => {

--- a/tests/e2e/solve/page.spec.ts
+++ b/tests/e2e/solve/page.spec.ts
@@ -1,0 +1,87 @@
+import { setSession } from "@/tests/__helpers__/signin";
+import {
+  test,
+  expect,
+  http,
+  HttpResponse,
+  passthrough,
+} from "next/experimental/testmode/playwright/msw";
+
+test.describe("/solve", () => {
+  test.describe("before singin", () => {
+    test("should not allow me to visit /solve", async ({ page }) => {
+      await page.goto("/solve");
+      await expect(page).toHaveURL("/signin");
+      const flash = page.getByText("サインインしてください");
+      await expect(flash).toBeVisible();
+    });
+  });
+
+  test.describe("after signin", () => {
+    test.use({
+      mswHandlers: [
+        [
+          http.get("http://localhost:3000/api/v1/user/sangaku_saves", () => {
+            return HttpResponse.json(
+              {
+                data: [
+                  {
+                    id: "1",
+                    type: "sangaku",
+                    attributes: {
+                      title: "test_title",
+                      description: "test_desc",
+                      source: "puts 'hi'",
+                      difficulty: "nomal",
+                      inputs: [
+                        {
+                          id: 1,
+                          content: "input",
+                        },
+                      ],
+                      author_name: "another_user",
+                    },
+                    relationships: {
+                      user: {
+                        data: {
+                          id: "1",
+                          type: "user",
+                        },
+                      },
+                      shrine: {
+                        data: null,
+                      },
+                    },
+                  },
+                ],
+              },
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                  "current-page": "1",
+                  "page-items": "20",
+                  "total-pages": "1",
+                  "total-count": "1",
+                },
+              },
+            );
+          }),
+          // allow all non-mocked routes to pass through
+          http.all("*", () => {
+            return passthrough();
+          }),
+        ],
+        { scope: "test" }, // or 'worker'
+      ],
+    });
+
+    test("should allow me to show saved_sangakus", async ({ page }) => {
+      await setSession(page);
+      await page.goto("/solve");
+      await expect(page).toHaveURL("/solve");
+      const sangakuTitle = page.getByRole("heading", { name: "test_title" });
+      await expect(sangakuTitle).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
- **add: 算額の写し作成機能の追加**
- **add: 算額の写し一覧ページの実装**

## 概要

- 算額の写し作成機能の追加
- 算額の写し一覧の追加

## 確認方法

1. 神社ごとの算額一覧ページにて、算額を写すボタンが利用可能なことを確認してください
2. ```/solve```にて算額の写しの一覧が表示されることを確認してください

## 影響範囲


## チェックリスト


- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] e2eテストを追加した
- [ ] 必要なドキュメントを作成した

## コメント
