### PR TITLE
add: 算額解答機能の追加

### DIFF
--- a/app/lib/actions/answer.ts
+++ b/app/lib/actions/answer.ts
@@ -1,0 +1,74 @@
+"use server";
+
+import { auth } from "@/auth";
+import { revalidatePath } from "next/cache";
+import { isRedirectError } from "next/dist/client/components/redirect-error";
+import { setFlash } from "@/app/lib/actions/flash";
+import { costomSignOut } from "./auth";
+import { redirect } from "next/navigation";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+
+export type State = {
+  errors?: {
+    source?: string[];
+  };
+  message?: string;
+};
+
+export const createAnswer = async (sangaku_id: string, source: string) => {
+  const session = await auth();
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${session?.accessToken}`,
+  };
+
+  const params = {
+    source,
+  };
+
+  try {
+    const res = await fetch(
+      `${apiUrl}/api/v1/user/sangakus/${sangaku_id}/answers`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify(params),
+      },
+    );
+
+    switch (res.status) {
+      case 200:
+        await setFlash({ type: "success", message: "算額を解答しました" });
+        revalidatePath("/saved_sangakus");
+        redirect(`/saved_sangakus/${sangaku_id}/answer`);
+      case 401:
+        await setFlash({
+          type: "error",
+          message:
+            "セッションの有効期限が切れています。\n再度ログインしてください",
+        });
+        await costomSignOut();
+        break;
+      case 400:
+        const data = await res.json();
+        await setFlash({ type: "error", message: "入力に誤りがあります" });
+        return {
+          errors: Object.fromEntries(data.errors),
+          message: "入力に誤りがあります",
+        } as State;
+      default:
+        await setFlash({ type: "error", message: "リクエストに失敗しました" });
+        return { message: "リクエストに失敗しました" } as State;
+    }
+  } catch (e) {
+    if (isRedirectError(e)) {
+      throw e;
+    }
+    await setFlash({ type: "error", message: "予期せぬエラーが発生しました" });
+    return {
+      message: "予期せぬエラーが発生しました",
+    } as State;
+  }
+};

--- a/app/lib/actions/sangaku.ts
+++ b/app/lib/actions/sangaku.ts
@@ -88,7 +88,6 @@ export const createSangaku = async (
     if (isRedirectError(error)) {
       throw error;
     }
-    console.log(error);
     await setFlash({ type: "error", message: "予期せぬエラーが発生しました" });
     return {
       // message: "予期せぬエラーが発生しました",

--- a/app/lib/data/answer.ts
+++ b/app/lib/data/answer.ts
@@ -1,0 +1,116 @@
+"use server";
+
+import { auth } from "@/auth";
+import type { Answer, AnswerResult } from "../definitions";
+import { isRedirectError } from "next/dist/client/components/redirect-error";
+
+const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+
+export const fetchUserAnswer = async (id: string) => {
+  const session = await auth();
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${session?.accessToken}`,
+  };
+
+  try {
+    while (true) {
+      const res = await fetch(`${apiUrl}/api/v1/user/answers/${id}`, {
+        headers,
+      });
+
+      switch (res.status) {
+        case 200:
+          const data = (await res.json()).data as Answer;
+          if (data.attributes.status !== "pending") {
+            return data;
+          } else {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+          }
+        case 401:
+          return undefined;
+        case 404:
+          return null;
+      }
+    }
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    } else {
+      return null;
+    }
+  }
+};
+
+export const fetchUserAnswerWithSangakuId = async (sangaku_id: string) => {
+  const session = await auth();
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${session?.accessToken}`,
+  };
+
+  try {
+    const res = await fetch(
+      `${apiUrl}/api/v1/user/saved_sangakus/${sangaku_id}/answer`,
+      {
+        headers,
+      },
+    );
+
+    switch (res.status) {
+      case 200:
+        const data = await res.json();
+        return data.data as Answer;
+      case 401:
+        return undefined;
+      case 404:
+        return null;
+    }
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    } else {
+      return null;
+    }
+  }
+};
+
+export const fetchUserAnswerResult = async (id: string) => {
+  const session = await auth();
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${session?.accessToken}`,
+  };
+
+  try {
+    while (true) {
+      const res = await fetch(`${apiUrl}/api/v1/user/answer_results/${id}`, {
+        headers,
+      });
+
+      switch (res.status) {
+        case 200:
+          const data = (await res.json()).data as AnswerResult;
+          if (data.attributes.status !== "pending") {
+            return data;
+          } else {
+            await new Promise((resolve) => setTimeout(resolve, 250));
+          }
+          break;
+        case 401:
+          return undefined;
+        case 404:
+          return null;
+      }
+    }
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    } else {
+      return null;
+    }
+  }
+};

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -43,3 +43,46 @@ export type Shrine = {
     place_id: string;
   };
 };
+
+type answerResultArray = { id: string; type: "answer_result" }[];
+
+export type Answer = {
+  id: string;
+  type: "answer";
+  attributes: {
+    source: string;
+    status: "correct" | "incorrect" | "pending";
+  };
+  relationships: {
+    user_sangaku_save: {
+      data: {
+        id: string;
+        type: "user_sangaku_save";
+      };
+    };
+    answer_results: {
+      data: answerResultArray;
+    };
+  };
+};
+
+export type AnswerResult = {
+  id: string;
+  type: "answer_result";
+  attributes: {
+    status: "correct" | "incorrect" | "pending";
+    output: string;
+    fixed_input_content: string;
+  };
+  relationships: {
+    answer: {
+      data: {
+        id: string;
+        type: "answer";
+      };
+    };
+    fixed_input: {
+      data: { id: string; type: "fixed_input" } | null;
+    };
+  };
+};

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ const linkContent = [
   { name: "算額を作る", href: "/sangakus/create" },
   { name: "算額を確認", href: "/user/sangakus" },
   { name: "神社を探す", href: "/shrines" },
-  { name: "算額を解く", href: "#" },
+  { name: "算額を解く", href: "/saved_sangakus" },
 ];
 
 export default function Home() {

--- a/app/saved_sangakus/[id]/answer/create/page.tsx
+++ b/app/saved_sangakus/[id]/answer/create/page.tsx
@@ -1,0 +1,18 @@
+import { fetchSavedSangaku } from "@/app/lib/data/sangaku";
+import { notFound } from "next/navigation";
+import Form from "@/app/ui/answer/create-form";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+export default async function Page(props: Props) {
+  const params = await props.params;
+  const id = params.id;
+  const sangaku = await fetchSavedSangaku(id, "before_answer");
+
+  if (!sangaku) {
+    notFound();
+  }
+
+  return <Form sangaku={sangaku} />;
+}

--- a/app/saved_sangakus/[id]/answer/page.tsx
+++ b/app/saved_sangakus/[id]/answer/page.tsx
@@ -1,0 +1,45 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import Grid from "@mui/material/Grid2";
+import Box from "@mui/material/Box";
+import { fetchUserAnswerWithSangakuId } from "@/app/lib/data/answer";
+import { fetchSavedSangaku } from "@/app/lib/data/sangaku";
+import Results from "@/app/ui/answer/Results";
+import SourceResult from "@/app/ui/answer/SourseResult";
+import ReadOnlyEditor from "@/app/ui/answer/ReadOnlyEditor";
+import { SourceResultLoading } from "@/app/ui/answer/LoadingCirclars";
+import { Typography } from "@mui/material";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function Page(props: Props) {
+  const params = await props.params;
+  const id = params.id;
+  const answer = await fetchUserAnswerWithSangakuId(id);
+  const sangaku = await fetchSavedSangaku(id);
+
+  if (!answer) {
+    notFound();
+  }
+
+  return (
+    <Box>
+      <Typography variant="h4" component="h1" mb={1}>
+        {sangaku?.attributes.title}の結果
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <ReadOnlyEditor value={answer.attributes.source} />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6 }}>
+          <Suspense fallback={<SourceResultLoading />}>
+            <SourceResult answer={answer} />
+          </Suspense>
+          <Results answer={answer} />
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}

--- a/app/saved_sangakus/page.tsx
+++ b/app/saved_sangakus/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { SangakuWithButtonListSkeleton } from "@/app/ui/skeletons";
-import SavedSangakuList from "@/app/ui/solve/SavedSangakuList";
+import SavedSangakuList from "@/app/ui/answer/SavedSangakuList";
 import { Box, Container, Typography } from "@mui/material";
 import Search from "@/app/ui/Search";
 

--- a/app/ui/answer/LoadingCirclars.tsx
+++ b/app/ui/answer/LoadingCirclars.tsx
@@ -1,0 +1,48 @@
+import { Box, CircularProgress } from "@mui/material";
+
+export function SourceResultLoading() {
+  return (
+    <Box display="flex" justifyContent="center" alignItems="center">
+      <CircularProgress size={240} sx={{ m: 3 }} />
+    </Box>
+  );
+}
+
+export function ResultLoading({ index }: { index: number }) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        borderBottom: "1px solid gray",
+      }}
+    >
+      <Box
+        sx={{
+          borderRight: "1px solid gray",
+          width: 30,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontWeight: "bold",
+        }}
+      >
+        {index + 1}
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="center"
+        sx={{ flexGrow: 1, p: 1, borderRight: "1px solid gray" }}
+      >
+        <CircularProgress size={24} />
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        sx={{ p: 1, width: 50 }}
+      >
+        <CircularProgress size={24} />
+      </Box>
+    </Box>
+  );
+}

--- a/app/ui/answer/ReadOnlyEditor.tsx
+++ b/app/ui/answer/ReadOnlyEditor.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Editor } from "@monaco-editor/react";
+
+interface Props {
+  value: string;
+}
+
+const readOnlyMessage = {
+  value: "このエディタでは編集できません\n作成画面に戻り編集してください",
+};
+
+export default function ReadOnlyEditor({ value }: Props) {
+  return (
+    <Editor
+      defaultLanguage="ruby"
+      height="70vh"
+      theme="vs-dark"
+      options={{ readOnly: true, readOnlyMessage }}
+      value={value}
+    />
+  );
+}

--- a/app/ui/answer/Result.tsx
+++ b/app/ui/answer/Result.tsx
@@ -1,0 +1,49 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { fetchUserAnswerResult } from "@/app/lib/data/answer";
+
+interface Props {
+  index: number;
+  id: string;
+}
+
+export default async function Result({ index, id }: Props) {
+  const result = await fetchUserAnswerResult(id);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        borderBottom: "1px solid gray",
+      }}
+    >
+      <Box
+        sx={{
+          borderRight: "1px solid gray",
+          width: 30,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          fontWeight: "bold",
+        }}
+      >
+        {index + 1}
+      </Box>
+      <Box sx={{ flexGrow: 1, p: 1, borderRight: "1px solid gray" }}>
+        <Typography aria-label={`result-${index + 1}`}>
+          {result?.attributes.output}
+        </Typography>
+      </Box>
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        sx={{ p: 1, width: 50 }}
+      >
+        <Typography>
+          {result?.attributes.status === "correct" ? "○" : "×"}
+        </Typography>
+      </Box>
+    </Box>
+  );
+}

--- a/app/ui/answer/Results.tsx
+++ b/app/ui/answer/Results.tsx
@@ -1,0 +1,67 @@
+import Box from "@mui/material/Box";
+import Result from "./Result";
+import { Answer } from "@/app/lib/definitions";
+import { Suspense } from "react";
+import { Typography } from "@mui/material";
+import { ResultLoading } from "./LoadingCirclars";
+
+interface Props {
+  answer: Answer;
+}
+
+export default function Results({ answer }: Props) {
+  const resultIds = answer.relationships.answer_results.data.map(
+    (result) => result.id,
+  );
+
+  return (
+    <Box
+      sx={{
+        border: "1px solid black",
+        borderRadius: 2,
+        overflow: "hidden",
+        width: "100%",
+      }}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          borderBottom: "1px solid gray",
+        }}
+      >
+        <Box
+          sx={{
+            borderRight: "1px solid gray",
+            width: 30,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontWeight: "bold",
+            py: 0.5,
+          }}
+        />
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="end"
+          sx={{ flexGrow: 1, p: 1, borderRight: "1px solid gray", py: 0.5 }}
+        >
+          <Typography>出力</Typography>
+        </Box>
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          sx={{ py: 0.5, width: 50 }}
+        >
+          <Typography>結果</Typography>
+        </Box>
+      </Box>
+      {resultIds.map((value, index) => (
+        <Suspense key={index} fallback={<ResultLoading index={index} />}>
+          <Result index={index} id={value} />
+        </Suspense>
+      ))}
+    </Box>
+  );
+}

--- a/app/ui/answer/SavedSangaku.tsx
+++ b/app/ui/answer/SavedSangaku.tsx
@@ -73,7 +73,11 @@ export default function SavedSangaku({ sangaku }: Props) {
         </Box>
       </Ema>
       <Box sx={{ display: "flex", justifyContent: "end", mt: 1 }}>
-        <Button variant="contained" href="#" LinkComponent={Link}>
+        <Button
+          variant="contained"
+          href={`/saved_sangakus/${sangaku.id}/answer/create`}
+          LinkComponent={Link}
+        >
           算額を解く
         </Button>
       </Box>

--- a/app/ui/answer/SavedSangakuList.tsx
+++ b/app/ui/answer/SavedSangakuList.tsx
@@ -1,5 +1,5 @@
 import Grid from "@mui/material/Grid2";
-import { Box, Typography } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 import { fetchSavedSangakus } from "@/app/lib/data/sangaku";
 import Pagination from "../Pagination";
 import SavedSangaku from "./SavedSangaku";
@@ -19,6 +19,7 @@ export default async function SavedSangakuList({
     page,
     query,
     difficulty,
+    "before_answer",
   );
 
   return (
@@ -39,9 +40,20 @@ export default async function SavedSangakuList({
           mb: 2,
         }}
       >
-        {sangakus.map((sangaku) => (
-          <SavedSangaku sangaku={sangaku} key={sangaku.id} />
-        ))}
+        {sangakus.length > 0 &&
+          sangakus.map((sangaku) => (
+            <SavedSangaku sangaku={sangaku} key={sangaku.id} />
+          ))}
+        {sangakus.length > 0 || (
+          <Box display="flex" justifyContent="center" alignItems="center">
+            <Typography variant="inherit" mr={1}>
+              算額がありません
+            </Typography>
+            <Button variant="contained" href="/shrines" sx={{ ml: 1 }}>
+              神社を探す
+            </Button>
+          </Box>
+        )}
       </Grid>
       <Box sx={{ display: "flex", justifyContent: "center" }}>
         <Pagination totalPage={totalPage} />

--- a/app/ui/answer/SourceExecution.tsx
+++ b/app/ui/answer/SourceExecution.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { runSource } from "@/app/lib/actions/sangaku";
+import { Box, Button, CircularProgress, TextField } from "@mui/material";
+import Grid from "@mui/material/Grid2";
+
+const initialOutput = "出力がこちらに表示されます。";
+
+interface Props {
+  source: string;
+}
+
+export default function SourceExecution({ source }: Props) {
+  const [input, setInput] = useState("");
+  const [output, setOutput] = useState(initialOutput);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleRunSource = async () => {
+    setIsLoading(true);
+    const result = await runSource(source, [input]);
+    setOutput(result[0]);
+    setIsLoading(false);
+  };
+
+  return (
+    <>
+      <Box display="flex" justifyContent="end">
+        <Button variant="contained" onClick={handleRunSource} sx={{ mb: 1 }}>
+          実行
+        </Button>
+      </Box>
+      <Grid container spacing={1} sx={{ mb: 2 }}>
+        <Grid size={6}>
+          <TextField
+            fullWidth
+            multiline
+            label="入力"
+            value={input}
+            rows={3}
+            onChange={(e) => {
+              setInput(e.target.value);
+            }}
+          />
+        </Grid>
+        <Grid
+          size={6}
+          justifyContent="center"
+          alignItems="center"
+          alignContent="center"
+        >
+          {isLoading || (
+            <TextField
+              fullWidth
+              multiline
+              label="出力"
+              value={output}
+              rows={3}
+              slotProps={{
+                input: {
+                  readOnly: true,
+                },
+              }}
+              aria-readonly={true}
+            />
+          )}
+          {isLoading && (
+            <CircularProgress
+              size="4rem"
+              sx={{ display: "block", m: "auto" }}
+            />
+          )}
+        </Grid>
+      </Grid>
+    </>
+  );
+}

--- a/app/ui/answer/SourseResult.tsx
+++ b/app/ui/answer/SourseResult.tsx
@@ -1,0 +1,61 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import type { Answer } from "@/app/lib/definitions";
+import { fetchUserAnswer } from "@/app/lib/data/answer";
+
+interface Props {
+  answer: Answer;
+}
+
+const size = 240;
+
+export default async function SourceResult({ answer }: Props) {
+  let data = answer;
+  if (answer.attributes.status === "pending") {
+    const ResultData = await fetchUserAnswer(answer.id);
+    if (ResultData) {
+      data = ResultData;
+    }
+  }
+
+  const isCorrect = data.attributes.status === "correct";
+
+  return (
+    <Box display="flex" justifyContent="center">
+      {isCorrect && (
+        <Box
+          width={size}
+          height={size}
+          border={3}
+          borderRadius="100%"
+          m={3}
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          sx={{ borderWidth: 4, borderColor: "#EB6101" }}
+        >
+          <Typography variant="h1" color="secondary.main">
+            明<br />察
+          </Typography>
+        </Box>
+      )}
+      {isCorrect || (
+        <Box
+          width={size}
+          height={size}
+          border={2}
+          borderRadius="100%"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          m={3}
+          sx={{ borderWidth: 5, borderColor: "#016AEB" }}
+        >
+          <Typography variant="h1" color="#016AEB">
+            誤<br />謬
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/ui/answer/create-form.tsx
+++ b/app/ui/answer/create-form.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState, useActionState } from "react";
+import { Editor } from "@monaco-editor/react";
+import Button from "@mui/material/Button";
+import Grid from "@mui/material/Grid2";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import type { Sangaku } from "@/app/lib/definitions";
+import { createAnswer, State } from "@/app/lib/actions/answer";
+import SourceExecution from "./SourceExecution";
+
+interface Props {
+  sangaku: Sangaku;
+}
+
+const initialSource = "# 対応言語: Ruby\ninput = gets.chomp\nputs input";
+const initialState: State = { errors: {} };
+
+export default function Form({ sangaku }: Props) {
+  const [source, setSource] = useState(initialSource);
+  const [state, formAction] = useActionState(postAnswerAction, initialState);
+
+  const handleEditorChange = (value: string | undefined) => {
+    if (typeof value === "string") {
+      setSource(value);
+    }
+  };
+
+  async function postAnswerAction() {
+    if (window.confirm("解答を終了しますか？")) {
+      const newState = await createAnswer(sangaku.id, source);
+      return newState;
+    }
+  }
+
+  return (
+    <form action={formAction}>
+      <Grid
+        container
+        spacing={2}
+        columns={{ xs: 6, md: 12 }}
+        sx={{ width: "100%" }}
+      >
+        <Grid size={6}>
+          {/* タイトル */}
+          <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
+            {sangaku.attributes.title}
+          </Typography>
+          {/* 問題文 */}
+          <Typography
+            height="65vh"
+            sx={{ p: 1, backgroundColor: "primary.main" }}
+          >
+            {sangaku.attributes.description}
+          </Typography>
+        </Grid>
+        <Grid size={6}>
+          {/* Editor */}
+          <Box sx={{ mb: 2 }}>
+            <Editor
+              theme="vs-dark"
+              height="60vh"
+              width="100%"
+              defaultLanguage="ruby"
+              value={source}
+              onChange={handleEditorChange}
+            />
+            {state?.errors?.source &&
+              state.errors.source.map((error: string) => (
+                <Typography
+                  aria-label="sourceError"
+                  key={error}
+                  sx={{ color: "red" }}
+                >
+                  {error}
+                </Typography>
+              ))}
+          </Box>
+          {/* input output */}
+          <SourceExecution source={source} />
+          <Box display="flex" justifyContent="end">
+            <Button variant="contained" type="submit">
+              解答を終了する
+            </Button>
+          </Box>
+        </Grid>
+      </Grid>
+    </form>
+  );
+}

--- a/app/ui/navigation/Drawer.tsx
+++ b/app/ui/navigation/Drawer.tsx
@@ -15,7 +15,7 @@ import { costomSignOut } from "@/app/lib/actions/auth";
 const drawerContent = [
   { text: "神社を探す", href: "/shrines" },
   { text: "算額を作る", href: "/sangakus/create" },
-  { text: "算額を解く", href: "/solve" },
+  { text: "算額を解く", href: "/saved_sangakus" },
   { text: "自分の算額を見る", href: "/user/sangakus" },
 ];
 

--- a/app/ui/sangaku/create-form.tsx
+++ b/app/ui/sangaku/create-form.tsx
@@ -19,11 +19,11 @@ import {
 import type { Difficulty } from "@/app/lib/definitions";
 
 const initialState: State = { errors: {} };
-const initilaSource = "# 対応言語: Ruby\ninput = gets.chomp\nputs input";
+const initialSource = "# 対応言語: Ruby\ninput = gets.chomp\nputs input";
 
 export default function Page() {
   const [state, formAction] = useActionState(postSangakuAction, initialState);
-  const [source, setSource] = useState(initilaSource);
+  const [source, setSource] = useState(initialSource);
   const [fixedInputs, setFixedInputs] = useState([""]);
   const [difficulty, setDifficulty] = useState<Difficulty>("nomal");
   const [modalOpen, setModalOpen] = useState(false);

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -1,0 +1,290 @@
+import { setSession } from "@/tests/__helpers__/signin";
+import {
+  test,
+  expect,
+  http,
+  HttpResponse,
+  passthrough,
+} from "next/experimental/testmode/playwright/msw";
+
+test.describe("/saved_sangakus/[id]/answer/create", () => {
+  test.describe("before signin", () => {
+    test("should not allow me to create answer", async ({ page }) => {
+      await page.goto("/saved_sangakus/1/answer/create");
+      await expect(page).toHaveURL("/signin");
+      const flash = page.getByText("サインインしてください");
+      await expect(flash).toBeVisible();
+    });
+  });
+
+  test.describe("after signin", () => {
+    test.use({
+      mswHandlers: [
+        [
+          http.get("http://localhost:3000/api/v1/user/saved_sangakus/1", () => {
+            return HttpResponse.json(
+              {
+                data: {
+                  id: "1",
+                  type: "sangaku",
+                  attributes: {
+                    title: "test_title",
+                    description: "test_desc",
+                    source: "input = gets.chomp\nputs input",
+                    difficulty: "nomal",
+                    inputs: [
+                      {
+                        id: 1,
+                        content: "test",
+                      },
+                    ],
+                    author_name: "another_user",
+                  },
+                  relationships: {
+                    user: {
+                      data: {
+                        id: "1",
+                        type: "user",
+                      },
+                    },
+                    shrine: {
+                      data: {
+                        id: "1",
+                        type: "shrine",
+                      },
+                    },
+                  },
+                },
+              },
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              },
+            );
+          }),
+          http.post(
+            "http://localhost:3000/api/v1/user/sangakus/1/answers",
+            () => {
+              return HttpResponse.json(
+                {
+                  data: {
+                    id: "1",
+                    type: "answer",
+                    attributes: {
+                      source: "input = gets.chomp\nputs input",
+                      status: "correct",
+                    },
+                    relationships: {
+                      user_sangaku_save: {
+                        data: {
+                          id: "1",
+                          type: "user_sangaku_save",
+                        },
+                      },
+                      answer_result: {
+                        data: [
+                          {
+                            id: "1",
+                            type: "answer_result",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+                {
+                  status: 200,
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                },
+              );
+            },
+          ),
+          http.get(
+            "http://localhost:3000/api/v1/user/saved_sangakus/1/answer",
+            () => {
+              return HttpResponse.json(
+                {
+                  data: {
+                    id: "1",
+                    type: "answer",
+                    attributes: {
+                      source: "input = gets.chomp\nputs input",
+                      status: "correct",
+                    },
+                    relationships: {
+                      user_sangaku_save: {
+                        data: {
+                          id: "1",
+                          type: "user_sangaku_save",
+                        },
+                      },
+                      answer_results: {
+                        data: [
+                          {
+                            id: "1",
+                            type: "answer_result",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+                {
+                  status: 200,
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                },
+              );
+            },
+          ),
+          http.get("http://localhost:3000/api/v1/user/answers/1", () => {
+            return HttpResponse.json(
+              {
+                data: {
+                  id: "1",
+                  type: "answer",
+                  attributes: {
+                    source: "input = gets.chomp\nputs input",
+                    status: "correct",
+                  },
+                  relationships: {
+                    user_sangaku_save: {
+                      data: {
+                        id: "1",
+                        type: "user_sangaku_save",
+                      },
+                    },
+                    answer_result: {
+                      data: [
+                        {
+                          id: "1",
+                          type: "answer_result",
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              },
+            );
+          }),
+          http.get("http://localhost:3000/api/v1/user/answer_results/1", () => {
+            return HttpResponse.json(
+              {
+                data: {
+                  id: "1",
+                  type: "answer_result",
+                  attributes: {
+                    output: "test\n",
+                    status: "correct",
+                    fixed_input_content: "test",
+                  },
+                  relationships: {
+                    answer: {
+                      data: {
+                        id: "1",
+                        type: "answer",
+                      },
+                    },
+                    fixed_input: {
+                      data: {
+                        id: "1",
+                        type: "fixed_input",
+                      },
+                    },
+                  },
+                },
+              },
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              },
+            );
+          }),
+          // allow all non-mocked routes to pass through
+          http.all("*", () => {
+            return passthrough();
+          }),
+        ],
+        { scope: "test" }, // or 'worker'
+      ],
+    });
+
+    test.describe("after signin", () => {
+      test("should allow me to create answer", async ({ page }) => {
+        await setSession(page);
+        await page.goto("/saved_sangakus/1/answer/create");
+        const title = page.getByRole("heading", { name: "test_title" });
+        await expect(title).toBeVisible();
+        const description = page.getByText("test_desc");
+        await expect(description).toBeVisible();
+        const monacoEditor = page.locator(".monaco-editor").nth(0);
+        await monacoEditor.click();
+        await page.keyboard.press("Meta+KeyA");
+        await page.keyboard.press("Backspace");
+        await page.keyboard.type("input = gets.chomp");
+        await page.keyboard.press("Enter");
+        await page.keyboard.press("Enter");
+        await page.keyboard.type("puts input");
+        const button = page.getByRole("button", { name: "解答を終了する" });
+        page.once("dialog", async (dialog) => {
+          await dialog.accept();
+        });
+        await button.click();
+        await expect(page).toHaveURL("/saved_sangakus/1/answer");
+        const heading = page.getByRole("heading", { name: "test_titleの結果" });
+        await expect(heading).toBeVisible();
+      });
+
+      test("should not allow me to create answer without source", async ({
+        page,
+        msw,
+      }) => {
+        msw.use(
+          http.post(
+            "http://localhost:3000/api/v1/user/sangakus/1/answers",
+            () => {
+              return HttpResponse.json(
+                {
+                  message: "Bad Request",
+                  errors: [["source", ["を入力してください"]]],
+                },
+                { status: 400 },
+              );
+            },
+          ),
+        );
+        await setSession(page);
+        await page.goto("/saved_sangakus/1/answer/create");
+        const title = page.getByRole("heading", { name: "test_title" });
+        await expect(title).toBeVisible();
+        const description = page.getByText("test_desc");
+        await expect(description).toBeVisible();
+        const monacoEditor = page.locator(".monaco-editor").nth(0);
+        await monacoEditor.click();
+        await page.keyboard.press("Meta+KeyA");
+        await page.keyboard.press("Backspace");
+        const button = page.getByRole("button", { name: "解答を終了する" });
+        page.once("dialog", async (dialog) => {
+          await dialog.accept();
+        });
+        await button.click();
+        await expect(page).toHaveURL("/saved_sangakus/1/answer/create");
+        const errorMessage = page.getByLabel("sourceError");
+        await expect(errorMessage).toBeVisible();
+      });
+    });
+  });
+});

--- a/tests/e2e/saved_sangakus/[id]/answer/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/page.spec.ts
@@ -1,0 +1,196 @@
+import { setSession } from "@/tests/__helpers__/signin";
+import {
+  test,
+  expect,
+  http,
+  HttpResponse,
+  passthrough,
+} from "next/experimental/testmode/playwright/msw";
+
+test.describe("/saved_sangakus/[id]/answer", () => {
+  test.describe("before signin", () => {
+    test("should not allow me to show answer", async ({ page }) => {
+      await page.goto("/saved_sangakus/1/answer");
+      await expect(page).toHaveURL("/signin");
+      const flash = page.getByText("サインインしてください");
+      await expect(flash).toBeVisible();
+    });
+  });
+
+  test.describe("after signin", () => {
+    test.use({
+      mswHandlers: [
+        [
+          http.get("http://localhost:3000/api/v1/user/saved_sangakus/1", () => {
+            return HttpResponse.json(
+              {
+                data: {
+                  id: "1",
+                  type: "sangaku",
+                  attributes: {
+                    title: "test_title",
+                    description: "test_desc",
+                    source: "input = gets.chomp\nputs input",
+                    difficulty: "nomal",
+                    inputs: [
+                      {
+                        id: 1,
+                        content: "test",
+                      },
+                    ],
+                    author_name: "another_user",
+                  },
+                  relationships: {
+                    user: {
+                      data: {
+                        id: "1",
+                        type: "user",
+                      },
+                    },
+                    shrine: {
+                      data: {
+                        id: "1",
+                        type: "shrine",
+                      },
+                    },
+                  },
+                },
+              },
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              },
+            );
+          }),
+          http.get(
+            "http://localhost:3000/api/v1/user/saved_sangakus/1/answer",
+            () => {
+              return HttpResponse.json(
+                {
+                  data: {
+                    id: "1",
+                    type: "answer",
+                    attributes: {
+                      source: "input = gets.chomp\nputs input",
+                      status: "correct",
+                    },
+                    relationships: {
+                      user_sangaku_save: {
+                        data: {
+                          id: "1",
+                          type: "user_sangaku_save",
+                        },
+                      },
+                      answer_results: {
+                        data: [
+                          {
+                            id: "1",
+                            type: "answer_result",
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+                {
+                  status: 200,
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                },
+              );
+            },
+          ),
+          http.get("http://localhost:3000/api/v1/user/answers/1", () => {
+            return HttpResponse.json(
+              {
+                data: {
+                  id: "1",
+                  type: "answer",
+                  attributes: {
+                    source: "input = gets.chomp\nputs input",
+                    status: "correct",
+                  },
+                  relationships: {
+                    user_sangaku_save: {
+                      data: {
+                        id: "1",
+                        type: "user_sangaku_save",
+                      },
+                    },
+                    answer_result: {
+                      data: [
+                        {
+                          id: "1",
+                          type: "answer_result",
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              },
+            );
+          }),
+          http.get("http://localhost:3000/api/v1/user/answer_results/1", () => {
+            return HttpResponse.json(
+              {
+                data: {
+                  id: "1",
+                  type: "answer_result",
+                  attributes: {
+                    output: "test\n",
+                    status: "correct",
+                    fixed_input_content: "test",
+                  },
+                  relationships: {
+                    answer: {
+                      data: {
+                        id: "1",
+                        type: "answer",
+                      },
+                    },
+                    fixed_input: {
+                      data: {
+                        id: "1",
+                        type: "fixed_input",
+                      },
+                    },
+                  },
+                },
+              },
+              {
+                status: 200,
+                headers: {
+                  "Content-Type": "application/json",
+                },
+              },
+            );
+          }),
+          // allow all non-mocked routes to pass through
+          http.all("*", () => {
+            return passthrough();
+          }),
+        ],
+        { scope: "test" }, // or 'worker'
+      ],
+    });
+
+    test("should allow me to show answer", async ({ page }) => {
+      await setSession(page);
+      await page.goto("/saved_sangakus/1/answer");
+      await expect(page).toHaveURL("/saved_sangakus/1/answer");
+      const heading = page.getByRole("heading", { name: "test_titleの結果" });
+      await expect(heading).toBeVisible();
+      const output = page.getByLabel("result-1");
+      await expect(output).toBeVisible();
+    });
+  });
+});

--- a/tests/e2e/saved_sangakus/page.spec.ts
+++ b/tests/e2e/saved_sangakus/page.spec.ts
@@ -7,10 +7,10 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-test.describe("/solve", () => {
+test.describe("/saved_sangakus", () => {
   test.describe("before singin", () => {
-    test("should not allow me to visit /solve", async ({ page }) => {
-      await page.goto("/solve");
+    test("should not allow me to visit /saved_sangakus", async ({ page }) => {
+      await page.goto("/answers");
       await expect(page).toHaveURL("/signin");
       const flash = page.getByText("サインインしてください");
       await expect(flash).toBeVisible();
@@ -21,7 +21,7 @@ test.describe("/solve", () => {
     test.use({
       mswHandlers: [
         [
-          http.get("http://localhost:3000/api/v1/user/sangaku_saves", () => {
+          http.get("http://localhost:3000/api/v1/user/saved_sangakus", () => {
             return HttpResponse.json(
               {
                 data: [
@@ -78,8 +78,8 @@ test.describe("/solve", () => {
 
     test("should allow me to show saved_sangakus", async ({ page }) => {
       await setSession(page);
-      await page.goto("/solve");
-      await expect(page).toHaveURL("/solve");
+      await page.goto("/saved_sangakus");
+      await expect(page).toHaveURL("/saved_sangakus");
       const sangakuTitle = page.getByRole("heading", { name: "test_title" });
       await expect(sangakuTitle).toBeVisible();
     });


### PR DESCRIPTION
解答作成、閲覧の追加、ルーティングの修正

## 概要
- 算額解答機能の追加
- 解答チェックページの追加
- 保存した算額一覧のルーティング変更
- APIの修正への対応

## 確認方法

1. サインイン後にドロワーより```算額を解く```を押下し、```/saved_sangakus```に遷移することを確認してください
2. 保存した算額のボタンより算額解答ページに遷移し、記述したソースコードの実行、算額の作成ができることを確認してください
3. 解答を終了後、解答結果ページへ遷移することを確認してください

## 影響範囲


## チェックリスト


- [x] インテグレーションテストを追加した
- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした
- [x] e2eテストをパスした
- [x] 必要なドキュメントを作成した

## コメント

