### PR TITLE
add: 解答済み算額一覧を追加

### DIFF
--- a/app/saved_sangakus/page.tsx
+++ b/app/saved_sangakus/page.tsx
@@ -3,9 +3,15 @@ import { SangakuWithButtonListSkeleton } from "@/app/ui/skeletons";
 import SavedSangakuList from "@/app/ui/answer/SavedSangakuList";
 import { Box, Container, Typography } from "@mui/material";
 import Search from "@/app/ui/Search";
+import PageTab from "../ui/answer/PageTab";
 
 interface Props {
-  searchParams: Promise<{ page: string; query: string; difficulty: string }>;
+  searchParams: Promise<{
+    page: string;
+    query: string;
+    difficulty: string;
+    tab: string;
+  }>;
 }
 
 export default async function Page(props: Props) {
@@ -13,21 +19,49 @@ export default async function Page(props: Props) {
   const page = searchParams.page || "1";
   const query = searchParams.query || "";
   const difficulty = searchParams.difficulty || "";
+  const tab = (await props.searchParams).tab || "before_answer";
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <Typography variant="h4" component="h1" sx={{ mb: 6 }}>
+      <Typography variant="h4" component="h1" sx={{ mb: 2 }}>
         算額を解く
       </Typography>
-      <Container maxWidth="md">
-        <Search placeholder="タイトルで探す" difficulty />
-      </Container>
-      <Suspense
-        key={page + query + difficulty}
-        fallback={<SangakuWithButtonListSkeleton width={102} />}
-      >
-        <SavedSangakuList page={page} query={query} difficulty={difficulty} />
-      </Suspense>
+      <PageTab />
+      {tab === "answered" ? (
+        <>
+          <Container maxWidth="md">
+            <Search placeholder="タイトルで探す" difficulty />
+          </Container>
+          <Suspense
+            key={page + query + difficulty}
+            fallback={<SangakuWithButtonListSkeleton width={102} />}
+          >
+            <SavedSangakuList
+              page={page}
+              query={query}
+              difficulty={difficulty}
+              type="answered"
+            />
+          </Suspense>
+        </>
+      ) : (
+        <>
+          <Container maxWidth="md">
+            <Search placeholder="タイトルで探す" difficulty />
+          </Container>
+          <Suspense
+            key={page + query + difficulty}
+            fallback={<SangakuWithButtonListSkeleton width={102} />}
+          >
+            <SavedSangakuList
+              page={page}
+              query={query}
+              difficulty={difficulty}
+              type="before_answer"
+            />
+          </Suspense>
+        </>
+      )}
     </Box>
   );
 }

--- a/app/ui/answer/PageTab.tsx
+++ b/app/ui/answer/PageTab.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Tab, Tabs } from "@mui/material";
+import { SyntheticEvent, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+export default function PageTab() {
+  const searchParams = useSearchParams();
+  const tab =
+    searchParams.get("tab") === "answered"
+      ? "/saved_sangakus?tab=answered"
+      : "/saved_sangakus";
+
+  const [value, setValue] = useState(tab);
+  const router = useRouter();
+
+  const handleChange = (_e: SyntheticEvent, newValue: string) => {
+    setValue(newValue);
+    router.push(newValue);
+  };
+
+  return (
+    <Tabs
+      centered
+      variant="fullWidth"
+      value={value}
+      onChange={handleChange}
+      sx={{ mb: 3 }}
+    >
+      <Tab value="/saved_sangakus" label="未解答" />
+      <Tab value="/saved_sangakus?tab=answered" label="解答済み" />
+    </Tabs>
+  );
+}

--- a/app/ui/answer/SavedSangaku.tsx
+++ b/app/ui/answer/SavedSangaku.tsx
@@ -7,9 +7,10 @@ import Link from "next/link";
 
 interface Props {
   sangaku: Sangaku;
+  answerd?: boolean;
 }
 
-export default function SavedSangaku({ sangaku }: Props) {
+export default function SavedSangaku({ sangaku, answerd }: Props) {
   return (
     <Grid key={sangaku.id}>
       <Ema width={18}>
@@ -73,13 +74,24 @@ export default function SavedSangaku({ sangaku }: Props) {
         </Box>
       </Ema>
       <Box sx={{ display: "flex", justifyContent: "end", mt: 1 }}>
-        <Button
-          variant="contained"
-          href={`/saved_sangakus/${sangaku.id}/answer/create`}
-          LinkComponent={Link}
-        >
-          算額を解く
-        </Button>
+        {answerd || (
+          <Button
+            variant="contained"
+            href={`/saved_sangakus/${sangaku.id}/answer/create`}
+            LinkComponent={Link}
+          >
+            算額を解く
+          </Button>
+        )}
+        {answerd && (
+          <Button
+            variant="contained"
+            href={`/saved_sangakus/${sangaku.id}/answer`}
+            LinkComponent={Link}
+          >
+            結果を見る
+          </Button>
+        )}
       </Box>
     </Grid>
   );

--- a/app/ui/answer/SavedSangakuList.tsx
+++ b/app/ui/answer/SavedSangakuList.tsx
@@ -8,18 +8,20 @@ interface Props {
   page: string;
   query: string;
   difficulty: string;
+  type: "before_answer" | "answered";
 }
 
 export default async function SavedSangakuList({
   page,
   query,
   difficulty,
+  type,
 }: Props) {
   const { sangakus, totalPage, message } = await fetchSavedSangakus(
     page,
     query,
     difficulty,
-    "before_answer",
+    type,
   );
 
   return (
@@ -42,7 +44,11 @@ export default async function SavedSangakuList({
       >
         {sangakus.length > 0 &&
           sangakus.map((sangaku) => (
-            <SavedSangaku sangaku={sangaku} key={sangaku.id} />
+            <SavedSangaku
+              sangaku={sangaku}
+              key={sangaku.id}
+              answerd={type === "answered"}
+            />
           ))}
         {sangakus.length > 0 || (
           <Box display="flex" justifyContent="center" alignItems="center">

--- a/tests/e2e/saved_sangakus/page.spec.ts
+++ b/tests/e2e/saved_sangakus/page.spec.ts
@@ -21,52 +21,104 @@ test.describe("/saved_sangakus", () => {
     test.use({
       mswHandlers: [
         [
-          http.get("http://localhost:3000/api/v1/user/saved_sangakus", () => {
-            return HttpResponse.json(
-              {
-                data: [
+          http.get(
+            "http://localhost:3000/api/v1/user/saved_sangakus",
+            ({ request }) => {
+              const url = new URL(request.url);
+              const type = url.searchParams.get("type");
+              if (type !== "answered") {
+                return HttpResponse.json(
                   {
-                    id: "1",
-                    type: "sangaku",
-                    attributes: {
-                      title: "test_title",
-                      description: "test_desc",
-                      source: "puts 'hi'",
-                      difficulty: "nomal",
-                      inputs: [
-                        {
-                          id: 1,
-                          content: "input",
+                    data: [
+                      {
+                        id: "1",
+                        type: "sangaku",
+                        attributes: {
+                          title: "test_title",
+                          description: "test_desc",
+                          source: "puts 'hi'",
+                          difficulty: "nomal",
+                          inputs: [
+                            {
+                              id: 1,
+                              content: "input",
+                            },
+                          ],
+                          author_name: "another_user",
                         },
-                      ],
-                      author_name: "another_user",
-                    },
-                    relationships: {
-                      user: {
-                        data: {
-                          id: "1",
-                          type: "user",
+                        relationships: {
+                          user: {
+                            data: {
+                              id: "1",
+                              type: "user",
+                            },
+                          },
+                          shrine: {
+                            data: null,
+                          },
                         },
                       },
-                      shrine: {
-                        data: null,
-                      },
+                    ],
+                  },
+                  {
+                    status: 200,
+                    headers: {
+                      "Content-Type": "application/json",
+                      "current-page": "1",
+                      "page-items": "20",
+                      "total-pages": "1",
+                      "total-count": "1",
                     },
                   },
-                ],
-              },
-              {
-                status: 200,
-                headers: {
-                  "Content-Type": "application/json",
-                  "current-page": "1",
-                  "page-items": "20",
-                  "total-pages": "1",
-                  "total-count": "1",
-                },
-              },
-            );
-          }),
+                );
+              } else {
+                return HttpResponse.json(
+                  {
+                    data: [
+                      {
+                        id: "1",
+                        type: "sangaku",
+                        attributes: {
+                          title: "answered",
+                          description: "test_desc",
+                          source: "puts 'hi'",
+                          difficulty: "nomal",
+                          inputs: [
+                            {
+                              id: 1,
+                              content: "input",
+                            },
+                          ],
+                          author_name: "another_user",
+                        },
+                        relationships: {
+                          user: {
+                            data: {
+                              id: "1",
+                              type: "user",
+                            },
+                          },
+                          shrine: {
+                            data: null,
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    status: 200,
+                    headers: {
+                      "Content-Type": "application/json",
+                      "current-page": "1",
+                      "page-items": "20",
+                      "total-pages": "1",
+                      "total-count": "1",
+                    },
+                  },
+                );
+              }
+            },
+          ),
           // allow all non-mocked routes to pass through
           http.all("*", () => {
             return passthrough();
@@ -81,6 +133,14 @@ test.describe("/saved_sangakus", () => {
       await page.goto("/saved_sangakus");
       await expect(page).toHaveURL("/saved_sangakus");
       const sangakuTitle = page.getByRole("heading", { name: "test_title" });
+      await expect(sangakuTitle).toBeVisible();
+    });
+
+    test("should allow me to show answered sangakus", async ({ page }) => {
+      await setSession(page);
+      await page.goto("/saved_sangakus?tab=answered");
+      await expect(page).toHaveURL("/saved_sangakus?tab=answered");
+      const sangakuTitle = page.getByRole("heading", { name: "answered" });
       await expect(sangakuTitle).toBeVisible();
     });
   });


### PR DESCRIPTION
## 概要
- 解答済み算額一覧を追加

## 確認方法

1. ```/saved_sangakus?tab=answered```に遷移し、解答済みの算額一覧が表示されることを確認してください

## 影響範囲


## チェックリスト

- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした
- [x] e2eテストをパスした

## コメント

