### PR TITLE
fix: コード生成ボタンに問題文の文字数制限を追加

### DIFF
--- a/app/ui/sangaku/create-form.tsx
+++ b/app/ui/sangaku/create-form.tsx
@@ -27,6 +27,7 @@ import type { Difficulty } from "@/app/lib/definitions";
 
 const initialState: State = { errors: {} };
 const initialSource = "# 対応言語: Ruby\ninput = gets.chomp\nputs input";
+const DESCRIPTION_MAX_LENGTH = 2000;
 
 export default function Page() {
   const [state, formAction] = useActionState(postSangakuAction, initialState);
@@ -119,6 +120,11 @@ export default function Page() {
               value={description}
               onChange={setDescription}
             />
+            {description.length > DESCRIPTION_MAX_LENGTH && (
+              <Typography sx={{ color: "red" }}>
+                問題文は{DESCRIPTION_MAX_LENGTH}文字以内で入力してください（現在{description.length}文字）
+              </Typography>
+            )}
             {state.errors?.description &&
               state.errors.description.map((error: string) => (
                 <Typography
@@ -163,7 +169,7 @@ export default function Page() {
                 variant="contained"
                 size="small"
                 onClick={handleGenerate}
-                disabled={isGenerating || !description.trim()}
+                disabled={isGenerating || !description.trim() || description.length > DESCRIPTION_MAX_LENGTH}
                 startIcon={
                   isGenerating ? <CircularProgress size={14} /> : undefined
                 }

--- a/app/ui/sangaku/edit-form.tsx
+++ b/app/ui/sangaku/edit-form.tsx
@@ -25,6 +25,8 @@ import {
 } from "@mui/material";
 import type { Sangaku, Difficulty } from "@/app/lib/definitions";
 
+const DESCRIPTION_MAX_LENGTH = 2000;
+
 interface Props {
   sangaku: Sangaku;
 }
@@ -133,6 +135,11 @@ export default function Form({ sangaku }: Props) {
               value={description}
               onChange={setDescription}
             />
+            {description.length > DESCRIPTION_MAX_LENGTH && (
+              <Typography sx={{ color: "red" }}>
+                問題文は{DESCRIPTION_MAX_LENGTH}文字以内で入力してください（現在{description.length}文字）
+              </Typography>
+            )}
             {state.errors?.description &&
               state.errors.description.map((error: string) => (
                 <Typography
@@ -177,7 +184,7 @@ export default function Form({ sangaku }: Props) {
                 variant="contained"
                 size="small"
                 onClick={handleGenerate}
-                disabled={isGenerating || !description.trim()}
+                disabled={isGenerating || !description.trim() || description.length > DESCRIPTION_MAX_LENGTH}
                 startIcon={
                   isGenerating ? <CircularProgress size={14} /> : undefined
                 }


### PR DESCRIPTION
## 概要

#57 のマージ後に追加したプロンプトインジェクション対策のフロントエンド側実装を反映する。

バックエンド（algo_sangaku_back #198）で `generate_source` エンドポイントに2000文字制限を追加したことに対応し、UIでも同様の制限を設けた。

## 確認方法

1. 算額作成画面（`/sangakus/create`）または編集画面を開く
2. 問題文に2000文字を超えるテキストを入力する
3. 「問題文からコードを生成」ボタンが無効化され、文字数オーバーのエラーメッセージが表示されることを確認する
4. 2000文字以内に戻すとボタンが有効になることを確認する

## 影響範囲

- `app/ui/sangaku/create-form.tsx` — 生成ボタンの `disabled` 条件と文字数エラー表示
- `app/ui/sangaku/edit-form.tsx` — 同上

## チェックリスト

- [ ] Lint のチェックをパスした（`pnpm lint`）
- [ ] ビルドをパスした（`pnpm build`）

## コメント

フロントエンドの制限はUX改善目的（APIエラーを事前に防ぐ）であり、セキュリティ上の主要な防御はバックエンド側で実施している。