### PR TITLE
feat: 算額コード生成ボタンに残り利用回数表示と上限到達時の無効化を追加

### DIFF
--- a/app/lib/actions/answer.ts
+++ b/app/lib/actions/answer.ts
@@ -4,7 +4,7 @@ import { auth } from "@/auth";
 import { revalidatePath } from "next/cache";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { setFlash } from "@/app/lib/actions/flash";
-import { costomSignOut } from "./auth";
+import { customSignOut } from "./auth";
 import { redirect } from "next/navigation";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
@@ -49,7 +49,7 @@ export const createAnswer = async (sangaku_id: string, source: string) => {
           message:
             "セッションの有効期限が切れています。\n再度ログインしてください",
         });
-        await costomSignOut();
+        await customSignOut();
         break;
       case 400:
         const data = await res.json();

--- a/app/lib/actions/auth.ts
+++ b/app/lib/actions/auth.ts
@@ -6,7 +6,7 @@ import { setFlash } from "./flash";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
-export async function costomSignOut() {
+export async function customSignOut() {
   const session = await auth();
   const headers: HeadersInit = {
     "Content-Type": "application/json",

--- a/app/lib/actions/profile.ts
+++ b/app/lib/actions/profile.ts
@@ -4,7 +4,7 @@ import { auth, unstable_update } from "@/auth";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { redirect } from "next/navigation";
 import { setFlash } from "@/app/lib/actions/flash";
-import { costomSignOut } from "./auth";
+import { customSignOut } from "./auth";
 import { User } from "../definitions";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
@@ -57,7 +57,7 @@ export const updateProfile = async (_prevState: State, formData: FormData) => {
           message:
             "セッションの有効期限が切れています。\n再度サインインしてください",
         });
-        await costomSignOut();
+        await customSignOut();
         return {} as State;
       case 400:
         const data = await res.json();

--- a/app/lib/actions/sangaku.ts
+++ b/app/lib/actions/sangaku.ts
@@ -5,8 +5,8 @@ import { revalidatePath } from "next/cache";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { redirect } from "next/navigation";
 import { setFlash } from "@/app/lib/actions/flash";
-import { Difficulty } from "../definitions";
-import { costomSignOut } from "./auth";
+import { Difficulty, GenerateSourceUsage } from "../definitions";
+import { customSignOut } from "./auth";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -67,7 +67,7 @@ export const createSangaku = async (
           message:
             "セッションの有効期限が切れています。\n再度サインインしてください",
         });
-        await costomSignOut();
+        await customSignOut();
         return {} as State;
       case 400:
         const data = await res.json();
@@ -141,7 +141,7 @@ export const updateSangaku = async (
           message:
             "セッションの有効期限が切れています。\n再度サインインしてください",
         });
-        await costomSignOut();
+        await customSignOut();
         return {} as State;
       case 400:
         const data = await res.json();
@@ -194,7 +194,7 @@ export const deleteSangaku = async (id: string) => {
           message:
             "セッションの有効期限が切れています。\n再度サインインしてください",
         });
-        await costomSignOut();
+        await customSignOut();
         break;
       default:
     }
@@ -305,7 +305,13 @@ interface Details {
   result: "success" | "fail" | "error" | null;
 }
 
-export const generateSource = async (description: string) => {
+export const generateSource = async (
+  description: string,
+): Promise<{
+  source?: string;
+  errorMessage?: string;
+  usage?: GenerateSourceUsage;
+}> => {
   const session = await auth();
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/sangakus/generate_source`, {
@@ -317,13 +323,27 @@ export const generateSource = async (description: string) => {
       body: JSON.stringify({ description }),
     });
 
-    if (!res.ok) throw new Error("コードの生成に失敗しました");
-    const data = await res.json();
-    return data.source as string;
+    switch (res.status) {
+      case 200: {
+        const data = await res.json();
+        return { source: data.source as string, usage: data.usage as GenerateSourceUsage };
+      }
+      case 401:
+        await customSignOut();
+        return {};
+      case 429:
+        return {
+          errorMessage:
+            "本日の利用上限に達しました。明日 3 時以降に再度お試しください。",
+        };
+      default:
+        return { errorMessage: "コードの生成に失敗しました" };
+    }
   } catch (e) {
     if (isRedirectError(e)) {
       throw e;
     }
+    return { errorMessage: "コードの生成に失敗しました" };
   }
 };
 

--- a/app/lib/actions/shrine.ts
+++ b/app/lib/actions/shrine.ts
@@ -4,7 +4,7 @@ import { auth } from "@/auth";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { setFlash } from "./flash";
 import { revalidatePath } from "next/cache";
-import { costomSignOut } from "./auth";
+import { customSignOut } from "./auth";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -42,7 +42,7 @@ export async function dedicateSangaku(
           message:
             "セッションの有効期限が切れています。\n再度ログインしてください",
         });
-        await costomSignOut();
+        await customSignOut();
         return false;
       default:
         await setFlash({ type: "error", message: "リクエストに失敗しました" });
@@ -88,7 +88,7 @@ export async function createSangakuSave(sangaku_id: string) {
           message:
             "セッションの有効期限が切れています。\n再度ログインしてください",
         });
-        await costomSignOut();
+        await customSignOut();
       default:
         await setFlash({ type: "error", message: "リクエストに失敗しました" });
     }

--- a/app/lib/data/sangaku.ts
+++ b/app/lib/data/sangaku.ts
@@ -2,7 +2,7 @@
 
 import { auth } from "@/auth";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
-import type { Sangaku, SangakuResult } from "../definitions";
+import type { Sangaku, SangakuResult, GenerateSourceUsage } from "../definitions";
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export async function fetchUserSangakus(
@@ -233,6 +233,38 @@ export async function fetchSavedSangaku(
   } catch (error) {
     if (isRedirectError(error)) {
       throw error;
+    }
+  }
+}
+
+export async function fetchGenerateSourceUsage(): Promise<GenerateSourceUsage | undefined> {
+  const session = await auth();
+
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${session?.accessToken}`,
+  };
+
+  try {
+    const res = await fetch(
+      `${apiUrl}/api/v1/user/sangakus/generate_source_usage`,
+      { headers },
+    );
+
+    switch (res.status) {
+      case 200:
+        const body = await res.json();
+        return body as GenerateSourceUsage;
+      case 401:
+        return undefined;
+      default:
+        return undefined;
+    }
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    } else {
+      return undefined;
     }
   }
 }

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -106,3 +106,10 @@ export interface SangakuResult {
     incorrect_count: number;
   };
 }
+
+export type GenerateSourceUsage = {
+  used: number;
+  limit: number;
+  remaining: number;
+  reset_at: string;
+};

--- a/app/sangakus/create/page.tsx
+++ b/app/sangakus/create/page.tsx
@@ -1,17 +1,19 @@
 import Form from "@/app/ui/sangaku/create-form";
 import { Box } from "@mui/material";
-
 import { Metadata } from "next";
+import { fetchGenerateSourceUsage } from "@/app/lib/data/sangaku";
 
 export const metadata: Metadata = {
   title: "算額を作る",
 };
 
-export default function Page() {
+export default async function Page() {
+  const initialUsage = await fetchGenerateSourceUsage();
+
   return (
     <Box>
       <h2 style={{ marginTop: 0 }}>算額を作る</h2>
-      <Form />
+      <Form initialUsage={initialUsage} />
     </Box>
   );
 }

--- a/app/ui/navigation/Drawer.tsx
+++ b/app/ui/navigation/Drawer.tsx
@@ -10,7 +10,7 @@ import ListItemText from "@mui/material/ListItemText";
 import Link from "@mui/material/Link";
 import Grid from "@mui/material/Grid2";
 import NextLink from "next/link";
-import { costomSignOut } from "@/app/lib/actions/auth";
+import { customSignOut } from "@/app/lib/actions/auth";
 
 const drawerContent = [
   { text: "神社を探す", href: "/shrines" },
@@ -36,7 +36,7 @@ export default function ResponsiveDrawer({
   const { data: session } = useSession();
   const handleSignout = async () => {
     if (window.confirm("サインアウトしますか？")) {
-      costomSignOut();
+      customSignOut();
     }
   };
 

--- a/app/ui/sangaku/create-form.tsx
+++ b/app/ui/sangaku/create-form.tsx
@@ -23,13 +23,18 @@ import {
   Select,
   SelectChangeEvent,
 } from "@mui/material";
-import type { Difficulty } from "@/app/lib/definitions";
+import type { Difficulty, GenerateSourceUsage } from "@/app/lib/definitions";
+import GenerateSourceUsageIndicator from "@/app/ui/sangaku/generate-source-usage-indicator";
 
 const initialState: State = { errors: {} };
 const initialSource = "# 対応言語: Ruby\ninput = gets.chomp\nputs input";
 const DESCRIPTION_MAX_LENGTH = 2000;
 
-export default function Page() {
+interface Props {
+  initialUsage: GenerateSourceUsage | undefined;
+}
+
+export default function Page({ initialUsage }: Props) {
   const [state, formAction] = useActionState(postSangakuAction, initialState);
   const [source, setSource] = useState(initialSource);
   const [description, setDescription] = useState("");
@@ -37,6 +42,8 @@ export default function Page() {
   const [difficulty, setDifficulty] = useState<Difficulty>("nomal");
   const [modalOpen, setModalOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [usage, setUsage] = useState<GenerateSourceUsage | undefined>(initialUsage);
+  const [generateErrorMessage, setGenerateErrorMessage] = useState<string | undefined>(undefined);
 
   async function postSangakuAction(prevState: State, formData: FormData) {
     const result = await createSangaku(
@@ -67,11 +74,19 @@ export default function Page() {
   const handleGenerate = async () => {
     if (!description.trim()) return;
     setIsGenerating(true);
-    const generated = await generateSource(description);
-    if (generated) {
-      setSource(generated);
+    setGenerateErrorMessage(undefined);
+    try {
+      const result = await generateSource(description);
+      if (result.source) setSource(result.source);
+      if (result.usage) {
+        setUsage(result.usage);
+      } else if (result.errorMessage) {
+        setUsage((prev) => (prev ? { ...prev, remaining: 0 } : prev));
+      }
+      if (result.errorMessage) setGenerateErrorMessage(result.errorMessage);
+    } finally {
+      setIsGenerating(false);
     }
-    setIsGenerating(false);
   };
 
   return (
@@ -165,17 +180,25 @@ export default function Page() {
               }}
             >
               <Typography component="span">ソースコード</Typography>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={handleGenerate}
-                disabled={isGenerating || !description.trim() || description.length > DESCRIPTION_MAX_LENGTH}
-                startIcon={
-                  isGenerating ? <CircularProgress size={14} /> : undefined
-                }
-              >
-                問題文からコードを生成
-              </Button>
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5 }}>
+                <GenerateSourceUsageIndicator usage={usage} />
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={handleGenerate}
+                  disabled={isGenerating || !description.trim() || description.length > DESCRIPTION_MAX_LENGTH || usage?.remaining === 0}
+                  startIcon={
+                    isGenerating ? <CircularProgress size={14} /> : undefined
+                  }
+                >
+                  問題文からコードを生成
+                </Button>
+                {generateErrorMessage && (
+                  <Typography variant="caption" sx={{ color: "error.main" }} aria-label="generateErrorMessage">
+                    {generateErrorMessage}
+                  </Typography>
+                )}
+              </Box>
             </Box>
             <Editor
               theme="vs-dark"

--- a/app/ui/sangaku/edit-form.tsx
+++ b/app/ui/sangaku/edit-form.tsx
@@ -23,15 +23,17 @@ import {
   Select,
   SelectChangeEvent,
 } from "@mui/material";
-import type { Sangaku, Difficulty } from "@/app/lib/definitions";
+import type { Sangaku, Difficulty, GenerateSourceUsage } from "@/app/lib/definitions";
+import GenerateSourceUsageIndicator from "@/app/ui/sangaku/generate-source-usage-indicator";
 
 const DESCRIPTION_MAX_LENGTH = 2000;
 
 interface Props {
   sangaku: Sangaku;
+  initialUsage: GenerateSourceUsage | undefined;
 }
 
-export default function Form({ sangaku }: Props) {
+export default function Form({ sangaku, initialUsage }: Props) {
   const initialState: State = {
     values: {
       title: sangaku.attributes.title,
@@ -51,6 +53,8 @@ export default function Form({ sangaku }: Props) {
   );
   const [modalOpen, setModalOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [usage, setUsage] = useState<GenerateSourceUsage | undefined>(initialUsage);
+  const [generateErrorMessage, setGenerateErrorMessage] = useState<string | undefined>(undefined);
 
   async function updateSangakuAction(prevState: State, formData: FormData) {
     const result = await updateSangaku(
@@ -82,11 +86,19 @@ export default function Form({ sangaku }: Props) {
   const handleGenerate = async () => {
     if (!description.trim()) return;
     setIsGenerating(true);
-    const generated = await generateSource(description);
-    if (generated) {
-      setSource(generated);
+    setGenerateErrorMessage(undefined);
+    try {
+      const result = await generateSource(description);
+      if (result.source) setSource(result.source);
+      if (result.usage) {
+        setUsage(result.usage);
+      } else if (result.errorMessage) {
+        setUsage((prev) => (prev ? { ...prev, remaining: 0 } : prev));
+      }
+      if (result.errorMessage) setGenerateErrorMessage(result.errorMessage);
+    } finally {
+      setIsGenerating(false);
     }
-    setIsGenerating(false);
   };
 
   return (
@@ -180,17 +192,25 @@ export default function Form({ sangaku }: Props) {
               }}
             >
               <Typography component="span">ソースコード</Typography>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={handleGenerate}
-                disabled={isGenerating || !description.trim() || description.length > DESCRIPTION_MAX_LENGTH}
-                startIcon={
-                  isGenerating ? <CircularProgress size={14} /> : undefined
-                }
-              >
-                問題文からコードを生成
-              </Button>
+              <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 0.5 }}>
+                <GenerateSourceUsageIndicator usage={usage} />
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={handleGenerate}
+                  disabled={isGenerating || !description.trim() || description.length > DESCRIPTION_MAX_LENGTH || usage?.remaining === 0}
+                  startIcon={
+                    isGenerating ? <CircularProgress size={14} /> : undefined
+                  }
+                >
+                  問題文からコードを生成
+                </Button>
+                {generateErrorMessage && (
+                  <Typography variant="caption" sx={{ color: "error.main" }} aria-label="generateErrorMessage">
+                    {generateErrorMessage}
+                  </Typography>
+                )}
+              </Box>
             </Box>
             <Editor
               theme="vs-dark"

--- a/app/ui/sangaku/generate-source-usage-indicator.tsx
+++ b/app/ui/sangaku/generate-source-usage-indicator.tsx
@@ -1,0 +1,25 @@
+import Typography from "@mui/material/Typography";
+import type { GenerateSourceUsage } from "@/app/lib/definitions";
+
+interface Props {
+  usage: GenerateSourceUsage | undefined;
+}
+
+export default function GenerateSourceUsageIndicator({ usage }: Props) {
+  if (usage === undefined) {
+    return (
+      <Typography variant="caption" sx={{ color: "text.disabled" }}>
+        本日の残り生成回数: - / -
+      </Typography>
+    );
+  }
+
+  return (
+    <Typography
+      variant="caption"
+      sx={{ color: usage.remaining === 0 ? "error.main" : "text.secondary" }}
+    >
+      本日の残り生成回数: {usage.remaining} / {usage.limit}
+    </Typography>
+  );
+}

--- a/app/user/sangakus/[id]/edit/page.tsx
+++ b/app/user/sangakus/[id]/edit/page.tsx
@@ -1,4 +1,4 @@
-import { fetchUserSangaku } from "@/app/lib/data/sangaku";
+import { fetchUserSangaku, fetchGenerateSourceUsage } from "@/app/lib/data/sangaku";
 import { notFound } from "next/navigation";
 import Form from "@/app/ui/sangaku/edit-form";
 import { Box } from "@mui/material";
@@ -16,7 +16,10 @@ export default async function Page(props: Props) {
   const params = await props.params;
   const id = params.id;
 
-  const sangaku = await fetchUserSangaku(id);
+  const [sangaku, initialUsage] = await Promise.all([
+    fetchUserSangaku(id),
+    fetchGenerateSourceUsage(),
+  ]);
 
   if (!sangaku) {
     notFound();
@@ -25,7 +28,7 @@ export default async function Page(props: Props) {
   return (
     <Box>
       <h2 style={{ marginTop: 0 }}>算額を編集する</h2>
-      <Form sangaku={sangaku} />
+      <Form sangaku={sangaku} initialUsage={initialUsage} />
     </Box>
   );
 }

--- a/tests/e2e/sangakus/create/page.spec.ts
+++ b/tests/e2e/sangakus/create/page.spec.ts
@@ -38,6 +38,12 @@ test.describe("/sangakus/create", () => {
               message: "success",
             });
           }),
+          http.get(`${apiUrl}/api/v1/user/sangakus/generate_source_usage`, () => {
+            return HttpResponse.json(
+              { used: 0, limit: 5, remaining: 5, reset_at: "2026-04-12T18:00:00Z" },
+              { status: 200 },
+            );
+          }),
           // allow all non-mocked routes to pass through
           http.all("*", () => {
             return passthrough();
@@ -154,7 +160,10 @@ test.describe("/sangakus/create", () => {
       msw.use(
         http.post(`${apiUrl}/api/v1/user/sangakus/generate_source`, () => {
           return HttpResponse.json(
-            { source: generatedSource },
+            {
+              source: generatedSource,
+              usage: { used: 1, limit: 5, remaining: 4, reset_at: "2026-04-12T18:00:00Z" },
+            },
             { status: 200 },
           );
         }),
@@ -263,6 +272,99 @@ test.describe("/sangakus/create", () => {
       const sourceErrorMessage = page.getByLabel("sourceError");
       await expect(sourceErrorMessage).toBeVisible();
       await expect(sourceErrorMessage).toHaveText("を入力してください");
+    });
+
+    test("shows usage indicator with remaining count", async ({ page }) => {
+      await setSession(page);
+      await page.goto("/sangakus/create");
+      await page.waitForLoadState();
+
+      const usageIndicator = page.getByText(/本日の残り生成回数: 5 \/ 5/);
+      await expect(usageIndicator).toBeVisible();
+    });
+
+    test("updates usage count after successful generation", async ({ page, msw }) => {
+      const generatedSource = "# 対応言語: Ruby\nn = gets.chomp.to_i\nputs n";
+
+      msw.use(
+        http.post(`${apiUrl}/api/v1/user/sangakus/generate_source`, () => {
+          return HttpResponse.json(
+            {
+              source: generatedSource,
+              usage: { used: 1, limit: 5, remaining: 4, reset_at: "2026-04-12T18:00:00Z" },
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await setSession(page);
+      await page.goto("/sangakus/create");
+      await page.waitForLoadState();
+
+      await page.getByLabel("問題文").fill("nを出力してください");
+      await page.getByRole("button", { name: "問題文からコードを生成" }).click();
+      await expect(page.getByRole("button", { name: "問題文からコードを生成" })).toBeEnabled({ timeout: 10000 });
+
+      const usageIndicator = page.getByText(/本日の残り生成回数: 4 \/ 5/);
+      await expect(usageIndicator).toBeVisible();
+    });
+
+    test("shows error message on 429 response", async ({ page, msw }) => {
+      msw.use(
+        http.post(`${apiUrl}/api/v1/user/sangakus/generate_source`, () => {
+          return HttpResponse.json({}, { status: 429 });
+        }),
+      );
+
+      await setSession(page);
+      await page.goto("/sangakus/create");
+      await page.waitForLoadState();
+
+      await page.getByLabel("問題文").fill("問題文を入力");
+      await page.getByRole("button", { name: "問題文からコードを生成" }).click();
+
+      const errorMessage = page.getByLabel("generateErrorMessage");
+      await expect(errorMessage).toBeVisible({ timeout: 10000 });
+      await expect(errorMessage).toHaveText(
+        "本日の利用上限に達しました。明日 3 時以降に再度お試しください。",
+      );
+      await expect(
+        page.getByRole("button", { name: "問題文からコードを生成" }),
+      ).toBeDisabled();
+    });
+  });
+
+  test.describe("when daily limit is reached", () => {
+    test.use({
+      mswHandlers: [
+        [
+          http.get(`${apiUrl}/up`, () => {
+            return HttpResponse.json({ message: "success" });
+          }),
+          http.get(`${apiUrl}/api/v1/user/sangakus/generate_source_usage`, () => {
+            return HttpResponse.json(
+              { used: 5, limit: 5, remaining: 0, reset_at: "2026-04-12T18:00:00Z" },
+              { status: 200 },
+            );
+          }),
+          http.all("*", () => passthrough()),
+        ],
+        { scope: "test" },
+      ],
+    });
+
+    test("generate button is disabled when remaining is 0", async ({ page }) => {
+      await setSession(page);
+      await page.goto("/sangakus/create");
+      await page.waitForLoadState();
+
+      await page.getByLabel("問題文").fill("問題文を入力");
+      const generateButton = page.getByRole("button", { name: "問題文からコードを生成" });
+      await expect(generateButton).toBeDisabled();
+
+      const usageIndicator = page.getByText(/本日の残り生成回数: 0 \/ 5/);
+      await expect(usageIndicator).toBeVisible();
     });
   });
 });

--- a/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
+++ b/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
@@ -64,6 +64,12 @@ test.describe("/user/sangakus/[id]/edit", () => {
           http.get(`${apiUrl}/api/v1/user/sangakus/999`, () => {
             return HttpResponse.json({}, { status: 404 });
           }),
+          http.get(`${apiUrl}/api/v1/user/sangakus/generate_source_usage`, () => {
+            return HttpResponse.json(
+              { used: 0, limit: 5, remaining: 5, reset_at: "2026-04-12T18:00:00Z" },
+              { status: 200 },
+            );
+          }),
           // allow all non-mocked routes to pass through
           http.all("*", () => {
             return passthrough();
@@ -184,7 +190,13 @@ test.describe("/user/sangakus/[id]/edit", () => {
 
       msw.use(
         http.post(`${apiUrl}/api/v1/user/sangakus/generate_source`, () => {
-          return HttpResponse.json({ source: generatedSource }, { status: 200 });
+          return HttpResponse.json(
+            {
+              source: generatedSource,
+              usage: { used: 1, limit: 5, remaining: 4, reset_at: "2026-04-12T18:00:00Z" },
+            },
+            { status: 200 },
+          );
         }),
         http.patch(`${apiUrl}/api/v1/user/sangakus/1`, () => {
           return HttpResponse.json(backendUpdateResponse, { status: 200 });
@@ -233,6 +245,117 @@ test.describe("/user/sangakus/[id]/edit", () => {
         name: "This page could not be found.",
       });
       await expect(message).toBeVisible();
+    });
+
+    test("shows usage indicator with remaining count", async ({ page }) => {
+      await setSession(page);
+      await page.goto("/user/sangakus/1/edit");
+      await page.waitForLoadState();
+
+      const usageIndicator = page.getByText(/本日の残り生成回数: 5 \/ 5/);
+      await expect(usageIndicator).toBeVisible();
+    });
+
+    test("updates usage count after successful generation", async ({ page, msw }) => {
+      const generatedSource = "# 対応言語: Ruby\nn = gets.chomp.to_i\nputs n";
+
+      msw.use(
+        http.post(`${apiUrl}/api/v1/user/sangakus/generate_source`, () => {
+          return HttpResponse.json(
+            {
+              source: generatedSource,
+              usage: { used: 1, limit: 5, remaining: 4, reset_at: "2026-04-12T18:00:00Z" },
+            },
+            { status: 200 },
+          );
+        }),
+      );
+
+      await setSession(page);
+      await page.goto("/user/sangakus/1/edit");
+      await page.waitForLoadState();
+
+      await expect(page.getByLabel("問題文")).toHaveValue("test_description");
+      await page.getByRole("button", { name: "問題文からコードを生成" }).click();
+      await expect(page.getByRole("button", { name: "問題文からコードを生成" })).toBeEnabled({ timeout: 10000 });
+
+      const usageIndicator = page.getByText(/本日の残り生成回数: 4 \/ 5/);
+      await expect(usageIndicator).toBeVisible();
+    });
+
+    test("shows error message on 429 response", async ({ page, msw }) => {
+      msw.use(
+        http.post(`${apiUrl}/api/v1/user/sangakus/generate_source`, () => {
+          return HttpResponse.json({}, { status: 429 });
+        }),
+      );
+
+      await setSession(page);
+      await page.goto("/user/sangakus/1/edit");
+      await page.waitForLoadState();
+
+      await page.getByRole("button", { name: "問題文からコードを生成" }).click();
+
+      const errorMessage = page.getByLabel("generateErrorMessage");
+      await expect(errorMessage).toBeVisible({ timeout: 10000 });
+      await expect(errorMessage).toHaveText(
+        "本日の利用上限に達しました。明日 3 時以降に再度お試しください。",
+      );
+      await expect(
+        page.getByRole("button", { name: "問題文からコードを生成" }),
+      ).toBeDisabled();
+    });
+  });
+
+  test.describe("when daily limit is reached", () => {
+    test.use({
+      mswHandlers: [
+        [
+          http.get(`${apiUrl}/up`, () => {
+            return HttpResponse.json({ message: "success" });
+          }),
+          http.get(`${apiUrl}/api/v1/user/sangakus/1`, () => {
+            return HttpResponse.json(
+              {
+                data: {
+                  id: "1",
+                  type: "sangaku",
+                  attributes: {
+                    title: "before_edit",
+                    description: "test_description",
+                    source: 'input = gets.chomp\nputs "test #{input}',
+                    difficulty: "nomal",
+                    inputs: [{ id: 1, content: "example" }],
+                  },
+                  relationships: { user: { data: { id: "1", type: "user" } } },
+                },
+              },
+              { status: 200 },
+            );
+          }),
+          http.get(`${apiUrl}/api/v1/user/sangakus/generate_source_usage`, () => {
+            return HttpResponse.json(
+              { used: 5, limit: 5, remaining: 0, reset_at: "2026-04-12T18:00:00Z" },
+              { status: 200 },
+            );
+          }),
+          http.all("*", () => passthrough()),
+        ],
+        { scope: "test" },
+      ],
+    });
+
+    test("generate button is disabled when remaining is 0", async ({ page }) => {
+      await setSession(page);
+      await page.goto("/user/sangakus/1/edit");
+      await page.waitForLoadState();
+
+      // 初期値（"test_description"）が入っていてもボタンはdisabledのまま
+      const generateButton = page.getByRole("button", { name: "問題文からコードを生成" });
+      await expect(generateButton).toBeDisabled();
+
+      const usageIndicator = page.getByText(/本日の残り生成回数: 0 \/ 5/);
+      await expect(usageIndicator).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## 概要

算額コード生成機能（`generateSource`）に1日5回の利用制限を追加するバックエンド実装（Alnoir-0011/algo_sangaku_back#215）に対応するフロントエンド実装です。

- 算額作成・編集フォームに「本日の残り生成回数: N / 5」を常時表示
- 残り 0 回の時はコード生成ボタンを disabled
- 上限到達（429）時は専用エラーメッセージを表示
- Server Component で初期 usage を事前取得し、初回レンダリング時のちらつきを回避
- 429 レスポンス後に usage.remaining を 0 に更新し、ボタンを即時 disabled にする

関連 issue: Alnoir-0011/algo_sangaku#59
親 issue: Alnoir-0011/algo_sangaku#30
バックエンド: Alnoir-0011/algo_sangaku_back#215

## 確認方法

1. バックエンド（`algo_sangaku_back#215`）を起動してください
2. 算額作成ページ（`/sangakus/create`）を開き、残り生成回数が表示されることを確認
3. 問題文を入力してコード生成ボタンを押すと残り回数が減ることを確認
4. 残り 0 回の状態でボタンが disabled になることを確認
5. E2E テストを実行して確認: `pnpm test:e2e -- -g "generate"`

## 影響範囲

- `app/ui/sangaku/create-form.tsx` — 作成フォームに usage 表示・disabled 制御を追加
- `app/ui/sangaku/edit-form.tsx` — 編集フォームに usage 表示・disabled 制御を追加
- `app/sangakus/create/page.tsx` — Server Component で初期 usage を取得
- `app/user/sangakus/[id]/edit/page.tsx` — Server Component で初期 usage を取得
- `app/lib/actions/sangaku.ts` — generateSource の戻り値・エラーハンドリングを修正
- `app/lib/data/sangaku.ts` — fetchGenerateSourceUsage を追加
- `app/lib/definitions.ts` — GenerateSourceUsage 型を追加
- E2E テスト（create / edit）に MSW ハンドラと新規テストを追加

## チェックリスト

- [x] インテグレーションテストを追加した
- [x] Lint のチェックをパスした

## コメント

- `generateSource` の 401 ハンドリングを既存の他 Action と同様に `customSignOut()` 呼び出しに統一しました（既存の不整合の合わせ修正）
- 429 受信時に `usage` が返らない場合でも、フロントエンド側で `remaining` を 0 に強制更新することで、ボタンが再び押せてしまう問題を防いでいます