### PR TITLE
fix: コンポーネントテストのServer Actions・useSessionエラーを解消

### DIFF
--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -35,9 +35,82 @@ export default defineConfig({
 
     ctViteConfig: {
       resolve: {
-        alias: {
-          "@/": path.join(__dirname, "./"),
-        },
+        alias: [
+          {
+            find: "next/navigation",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/navigation.ts",
+            ),
+          },
+          {
+            find: "@monaco-editor/react",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/monaco-editor.tsx",
+            ),
+          },
+          {
+            find: "@/app/lib/actions/auth",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/actions/auth.ts",
+            ),
+          },
+          {
+            find: "@/app/lib/actions/sangaku",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/actions/sangaku.ts",
+            ),
+          },
+          {
+            find: "@/app/lib/actions/shrine",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/actions/shrine.ts",
+            ),
+          },
+          {
+            find: "@/app/lib/actions/profile",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/actions/profile.ts",
+            ),
+          },
+          {
+            find: "@/app/lib/actions/flash",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/actions/flash.ts",
+            ),
+          },
+          {
+            find: "@/app/lib/data/answer",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/data/answer.ts",
+            ),
+          },
+          {
+            find: "@/app/lib/data/shrine",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/data/shrine.ts",
+            ),
+          },
+          {
+            find: "@/app/lib/data/sangaku",
+            replacement: path.join(
+              __dirname,
+              "./tests/__mocks__/data/sangaku.ts",
+            ),
+          },
+          {
+            find: "@/",
+            replacement: path.join(__dirname, "./"),
+          },
+        ],
       },
     },
   },

--- a/playwright/index.tsx
+++ b/playwright/index.tsx
@@ -6,10 +6,15 @@ import { ThemeProvider } from "@mui/material/styles";
 import { CssBaseline } from "@mui/material";
 import theme from "@/theme";
 import { SessionProvider } from "next-auth/react";
+import type { Session } from "next-auth";
 
-beforeMount(({ App }) => {
+type HooksConfig = {
+  session?: Session | null;
+};
+
+beforeMount<HooksConfig>(({ App, hooksConfig }) => {
   return Promise.resolve(
-    <SessionProvider>
+    <SessionProvider session={hooksConfig?.session ?? undefined}>
       <AppRouterCacheProvider>
         <ThemeProvider theme={theme}>
           <CssBaseline />

--- a/tests/__mocks__/actions/auth.ts
+++ b/tests/__mocks__/actions/auth.ts
@@ -1,0 +1,1 @@
+export const customSignOut = async (): Promise<void> => {};

--- a/tests/__mocks__/actions/flash.ts
+++ b/tests/__mocks__/actions/flash.ts
@@ -1,0 +1,4 @@
+export type FlashType = "error" | "info" | "success" | "warning";
+
+export const setFlash = async () => {};
+export const getFlash = async () => null;

--- a/tests/__mocks__/actions/profile.ts
+++ b/tests/__mocks__/actions/profile.ts
@@ -1,0 +1,14 @@
+export type State = {
+  errors?: {
+    nickname?: string[];
+  };
+  values?: {
+    nickname?: string;
+  };
+  message?: string;
+};
+
+export const updateProfile = async (
+  _prevState: State,
+  _formData: FormData,
+): Promise<State> => ({});

--- a/tests/__mocks__/actions/sangaku.ts
+++ b/tests/__mocks__/actions/sangaku.ts
@@ -1,0 +1,8 @@
+export const deleteSangaku = async (_id: string): Promise<void> => {};
+export const createSangaku = async () => ({});
+export const updateSangaku = async () => ({});
+export const generateSource = async () => ({});
+export const runSource = async (
+  _source: string,
+  _inputs: string[],
+): Promise<string[]> => ["mock output"];

--- a/tests/__mocks__/actions/shrine.ts
+++ b/tests/__mocks__/actions/shrine.ts
@@ -1,0 +1,2 @@
+export const createSangakuSave = async (_id: string): Promise<void> => {};
+export const dedicateSangaku = async () => ({});

--- a/tests/__mocks__/data/answer.ts
+++ b/tests/__mocks__/data/answer.ts
@@ -1,0 +1,32 @@
+import type { AnswerResult, Answer } from "@/app/lib/definitions";
+
+export const fetchUserAnswerResult = async (
+  _id: string,
+): Promise<AnswerResult | null> => ({
+  id: "1",
+  type: "answer_result",
+  attributes: {
+    status: "correct",
+    output: "mock output",
+    fixed_input_content: "1",
+  },
+  relationships: {
+    answer: { data: { id: "1", type: "answer" } },
+    fixed_input: { data: { id: "1", type: "fixed_input" } },
+  },
+});
+
+export const fetchUserAnswer = async (
+  _id: string,
+): Promise<Answer | null> => ({
+  id: "1",
+  type: "answer",
+  attributes: {
+    source: "puts 'hi'",
+    status: "correct",
+  },
+  relationships: {
+    user_sangaku_save: { data: { id: "1", type: "user_sangaku_save" } },
+    answer_results: { data: [] },
+  },
+});

--- a/tests/__mocks__/data/sangaku.ts
+++ b/tests/__mocks__/data/sangaku.ts
@@ -1,0 +1,20 @@
+import type { SangakuResult } from "@/app/lib/definitions";
+
+export const fetchUserSangakus = async () => ({
+  data: [],
+  meta: { total_pages: 1 },
+});
+
+export const fetchUserSangakuResult = async (
+  _id: string,
+): Promise<SangakuResult | null> => ({
+  attributes: {
+    user_sangaku_save_count: 5,
+    correct_count: 3,
+    incorrect_count: 2,
+  },
+});
+
+export const fetchShrineSangakus = async () => ({ data: [] });
+
+export const fetchSavedSangakus = async () => ({ data: [] });

--- a/tests/__mocks__/data/shrine.ts
+++ b/tests/__mocks__/data/shrine.ts
@@ -1,0 +1,15 @@
+import type { Shrine } from "@/app/lib/definitions";
+
+export const fetchShrines = async (): Promise<Shrine[]> => [];
+
+export const fetchShrine = async (_id: string): Promise<Shrine | null> => ({
+  id: "1",
+  type: "shrine",
+  attributes: {
+    name: "テスト神社",
+    address: "東京都テスト区1-1-1",
+    latitude: "35.6762",
+    longitude: "139.6503",
+    place_id: "place123",
+  },
+});

--- a/tests/__mocks__/monaco-editor.tsx
+++ b/tests/__mocks__/monaco-editor.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+interface EditorProps {
+  value?: string;
+  height?: string | number;
+  defaultLanguage?: string;
+  theme?: string;
+  options?: Record<string, unknown>;
+  onChange?: (value: string | undefined) => void;
+  [key: string]: unknown;
+}
+
+export function Editor({ value }: EditorProps) {
+  return React.createElement(
+    "div",
+    { "data-testid": "monaco-editor" },
+    value,
+  );
+}
+
+export default Editor;

--- a/tests/__mocks__/navigation.ts
+++ b/tests/__mocks__/navigation.ts
@@ -1,0 +1,20 @@
+export const useServerInsertedHTML = (_callback: () => unknown) => {};
+
+export const useRouter = () => ({
+  push: (_url: string) => {},
+  replace: (_url: string) => {},
+  back: () => {},
+  forward: () => {},
+  refresh: () => {},
+  prefetch: (_url: string) => {},
+});
+
+export const useSearchParams = () => new URLSearchParams();
+
+export const usePathname = () => "/";
+
+export const useParams = () => ({});
+
+export const redirect = (_url: string) => {};
+
+export const notFound = () => {};

--- a/tests/components/answer/LoadingCirclars.spec.tsx
+++ b/tests/components/answer/LoadingCirclars.spec.tsx
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import {
+  SourceResultLoading,
+  ResultLoading,
+} from "@/app/ui/answer/LoadingCirclars";
+
+test.describe("SourceResultLoading", () => {
+  test("renders loading indicator", async ({ mount, page }) => {
+    await mount(<SourceResultLoading />);
+    await expect(
+      page.locator(".MuiCircularProgress-root"),
+    ).toBeVisible();
+  });
+});
+
+test.describe("ResultLoading", () => {
+  test("renders loading indicator with index", async ({ mount }) => {
+    const component = await mount(<ResultLoading index={0} />);
+    await expect(component.getByText("1")).toBeVisible();
+  });
+
+  test("renders correct index number", async ({ mount }) => {
+    const component = await mount(<ResultLoading index={2} />);
+    await expect(component.getByText("3")).toBeVisible();
+  });
+});

--- a/tests/components/flash/FlashMessagePresentation.spec.tsx
+++ b/tests/components/flash/FlashMessagePresentation.spec.tsx
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import FlashMessagePresentation from "@/app/ui/flash/FlashMessagePresentation";
+
+test.describe("FlashMessagePresentation", () => {
+  test("shows success message", async ({ mount }) => {
+    const component = await mount(
+      <FlashMessagePresentation type="success" message="操作が完了しました" />,
+    );
+    await expect(component.getByText("操作が完了しました")).toBeVisible();
+  });
+
+  test("shows error message", async ({ mount }) => {
+    const component = await mount(
+      <FlashMessagePresentation type="error" message="エラーが発生しました" />,
+    );
+    await expect(component.getByText("エラーが発生しました")).toBeVisible();
+  });
+
+  test("shows info message", async ({ mount }) => {
+    const component = await mount(
+      <FlashMessagePresentation type="info" message="情報メッセージ" />,
+    );
+    await expect(component.getByText("情報メッセージ")).toBeVisible();
+  });
+
+  test("shows warning message", async ({ mount }) => {
+    const component = await mount(
+      <FlashMessagePresentation type="warning" message="警告メッセージ" />,
+    );
+    await expect(component.getByText("警告メッセージ")).toBeVisible();
+  });
+});

--- a/tests/components/navigation/Drawer.spec.tsx
+++ b/tests/components/navigation/Drawer.spec.tsx
@@ -1,13 +1,18 @@
 import { test, expect } from "@playwright/experimental-ct-react";
+import type { Session } from "next-auth";
 import Drawer from "@/app/ui/navigation/Drawer";
-import { mockClientSession } from "../../__helpers__/signin";
 
-test.describe.skip("Drawer", () => {
+const mockSession: Session = {
+  user: {
+    name: "testuser",
+    email: "test_user@example.com",
+    image: "https://avatars.githubusercontent.com/u/000000",
+  },
+  expires: "dummy",
+};
+
+test.describe("Drawer", () => {
   test.describe("before login", () => {
-    test.beforeEach(async ({ page }) => {
-      await mockClientSession(page, null);
-    });
-
     test("has AppName", async ({ mount }) => {
       const component = await mount(
         <Drawer
@@ -16,6 +21,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: null } },
       );
       const heading = component.getByRole("link", { name: "アルゴ算額" });
       await expect(heading).toBeVisible();
@@ -29,6 +35,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: null } },
       );
       const link = component.getByRole("link", { name: "神社を探す" });
       await expect(link).toBeVisible();
@@ -43,6 +50,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: null } },
       );
       const button = component.getByRole("button", { name: "サインイン" });
       await expect(button).toBeVisible();
@@ -56,6 +64,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: null } },
       );
       const link = component.getByRole("link", {
         name: "プライバシーポリシー",
@@ -72,6 +81,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: null } },
       );
       const link = component.getByRole("link", { name: "利用規約" });
       await expect(link).toBeVisible();
@@ -80,19 +90,6 @@ test.describe.skip("Drawer", () => {
   });
 
   test.describe("after login", () => {
-    test.beforeEach(async ({ page }) => {
-      const json = {
-        user: {
-          name: "testuser",
-          email: "test_user@example.com",
-          picture: "https://avatars.githubusercontent.com/u/000000",
-          nickname: "test nickname",
-        },
-        expires: "dummy",
-        idToken: "dummy",
-      };
-      await mockClientSession(page, json);
-    });
     test("has AppName", async ({ mount }) => {
       const component = await mount(
         <Drawer
@@ -101,6 +98,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const heading = component.getByRole("link", { name: "アルゴ算額" });
       await expect(heading).toBeVisible();
@@ -114,13 +112,14 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const link = component.getByRole("link", { name: "神社を探す" });
       await expect(link).toBeVisible();
       await expect(link).toHaveAttribute("href", "/shrines");
     });
 
-    test("has not link to SignIn page", async ({ mount }) => {
+    test("has not button to SignIn page", async ({ mount }) => {
       const component = await mount(
         <Drawer
           drawerWidth={240}
@@ -128,10 +127,10 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
-      const link = component.getByRole("button", { name: "サインイン" });
-      await expect(link).not.toBeVisible();
-      // await expect(link).toHaveAttribute("href", "/login");
+      const button = component.getByRole("button", { name: "サインイン" });
+      await expect(button).not.toBeVisible();
     });
 
     test("has link to CreateSangaku page", async ({ mount }) => {
@@ -142,6 +141,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const link = component.getByRole("link", { name: "算額を作る" });
       await expect(link).toBeVisible();
@@ -156,10 +156,11 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const link = component.getByRole("link", { name: "算額を解く" });
       await expect(link).toBeVisible();
-      await expect(link).toHaveAttribute("href", "/solve");
+      await expect(link).toHaveAttribute("href", "/saved_sangakus");
     });
 
     test("has link to ShowOwnSangaku page", async ({ mount }) => {
@@ -170,6 +171,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const link = component.getByRole("link", { name: "自分の算額を見る" });
       await expect(link).toBeVisible();
@@ -184,13 +186,14 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const link = component.getByRole("link", { name: "プロフィール編集" });
       await expect(link).toBeVisible();
       await expect(link).toHaveAttribute("href", "/user/profile");
     });
 
-    test("has link to Logout", async ({ mount }) => {
+    test("has signout button", async ({ mount }) => {
       const component = await mount(
         <Drawer
           drawerWidth={240}
@@ -198,8 +201,9 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
-      const button = component.getByRole("button", { name: "ログアウト" });
+      const button = component.getByRole("button", { name: "サインアウト" });
       await expect(button).toBeVisible();
     });
 
@@ -211,6 +215,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const link = component.getByRole("link", {
         name: "プライバシーポリシー",
@@ -227,6 +232,7 @@ test.describe.skip("Drawer", () => {
           handleDrawerTransitionEnd={() => {}}
           handleDrawerClose={() => {}}
         />,
+        { hooksConfig: { session: mockSession } },
       );
       const link = component.getByRole("link", { name: "利用規約" });
       await expect(link).toBeVisible();

--- a/tests/components/navigation/ResponsiveNav.spec.tsx
+++ b/tests/components/navigation/ResponsiveNav.spec.tsx
@@ -1,28 +1,22 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import ResponsiveNav from "@/app/ui/navigation/ResponsiveNav";
 
-// useSession()のモック化が厳しいためスキップ、代替を../page.spec.tsに追加
-test.describe.skip("ResponsiveNav", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.route(
-      "http://localhost:3100/api/auth/session",
-      async (route) => {
-        await route.fulfill({});
-      },
-    );
-  });
-
+test.describe("ResponsiveNav", () => {
   test.describe("Desktop", () => {
     test.use({ viewport: { width: 1024, height: 720 } });
 
     test("has not hamberger-menu button", async ({ mount }) => {
-      const component = await mount(<ResponsiveNav drawerWidth={240} />);
+      const component = await mount(<ResponsiveNav drawerWidth={240} />, {
+        hooksConfig: { session: null },
+      });
       const button = component.getByRole("button", { name: "opne drawer" });
       await expect(button).not.toBeVisible();
     });
 
     test("has opened sidenav", async ({ mount }) => {
-      const component = await mount(<ResponsiveNav drawerWidth={240} />);
+      const component = await mount(<ResponsiveNav drawerWidth={240} />, {
+        hooksConfig: { session: null },
+      });
       const appName = component.getByRole("link", { name: "アルゴ算額" });
       await expect(appName).toBeVisible();
     });
@@ -33,15 +27,14 @@ test.describe.skip("ResponsiveNav", () => {
 
     // 画面上には表示されるがコンポーネントテストで要素を取得できないためexample.spec.tsxに代替のテストを記載
     test.skip("opne drawer when click button", async ({ mount }) => {
-      const component = await mount(<ResponsiveNav drawerWidth={240} />);
+      const component = await mount(<ResponsiveNav drawerWidth={240} />, {
+        hooksConfig: { session: null },
+      });
       await expect(
         component.getByRole("link", { name: "アルゴ算額" }),
       ).not.toBeVisible();
       const button = component.getByRole("button", { name: "open drawer" });
       await button.click();
-      // const appName = component.getByRole("link", { name: 'アルゴ算額' });
-      // const appName = drawerRoot.getByText('アルゴ算額').;
-      // await expect(appName).toBeVisible();
       await expect(
         component.getByRole("link", { name: "アルゴ算額" }),
       ).toBeVisible();

--- a/tests/components/sangaku/FixedInputField.spec.tsx
+++ b/tests/components/sangaku/FixedInputField.spec.tsx
@@ -1,16 +1,5 @@
 import { test, expect } from "@playwright/experimental-ct-react";
-import { useState } from "react";
-import FixedInputField from "@/app/ui/sangaku/FixedInputField";
-
-function FixedInputFieldWrapper({ initial }: { initial: string[] }) {
-  const [fixedInputs, setFixedInputs] = useState(initial);
-  return (
-    <FixedInputField
-      fixedInputs={fixedInputs}
-      setFixedInputs={setFixedInputs}
-    />
-  );
-}
+import { FixedInputFieldWrapper } from "./FixedInputFieldStories";
 
 test.describe("FixedInputField", () => {
   test("renders input fields", async ({ mount }) => {

--- a/tests/components/sangaku/FixedInputField.spec.tsx
+++ b/tests/components/sangaku/FixedInputField.spec.tsx
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { useState } from "react";
+import FixedInputField from "@/app/ui/sangaku/FixedInputField";
+
+function FixedInputFieldWrapper({ initial }: { initial: string[] }) {
+  const [fixedInputs, setFixedInputs] = useState(initial);
+  return (
+    <FixedInputField
+      fixedInputs={fixedInputs}
+      setFixedInputs={setFixedInputs}
+    />
+  );
+}
+
+test.describe("FixedInputField", () => {
+  test("renders input fields", async ({ mount }) => {
+    const component = await mount(
+      <FixedInputFieldWrapper initial={["入力1", "入力2"]} />,
+    );
+    await expect(component.getByLabel("fixedInput-1")).toBeVisible();
+    await expect(component.getByLabel("fixedInput-2")).toBeVisible();
+  });
+
+  test("shows index numbers", async ({ mount }) => {
+    const component = await mount(
+      <FixedInputFieldWrapper initial={["a", "b"]} />,
+    );
+    await expect(component.getByText("1")).toBeVisible();
+    await expect(component.getByText("2")).toBeVisible();
+  });
+
+  test("has add button", async ({ mount }) => {
+    const component = await mount(<FixedInputFieldWrapper initial={[]} />);
+    await expect(
+      component.getByRole("button", { name: "addButton" }),
+    ).toBeVisible();
+  });
+
+  test("has remove buttons for each field", async ({ mount }) => {
+    const component = await mount(
+      <FixedInputFieldWrapper initial={["a", "b"]} />,
+    );
+    const deleteButtons = component.getByRole("button", { name: "削除" });
+    await expect(deleteButtons).toHaveCount(2);
+  });
+
+  test("adds a new field when add button is clicked", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<FixedInputFieldWrapper initial={["a"]} />);
+    await page.getByRole("button", { name: "addButton" }).click();
+    await expect(page.getByLabel("fixedInput-2")).toBeVisible();
+  });
+
+  test("removes a field when delete button is clicked", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<FixedInputFieldWrapper initial={["a", "b"]} />);
+    await page.getByRole("button", { name: "削除" }).first().click();
+    await expect(page.getByLabel("fixedInput-1")).toBeVisible();
+    await expect(page.getByLabel("fixedInput-2")).not.toBeVisible();
+  });
+});

--- a/tests/components/sangaku/FixedInputFieldStories.tsx
+++ b/tests/components/sangaku/FixedInputFieldStories.tsx
@@ -1,0 +1,12 @@
+import { useState } from "react";
+import FixedInputField from "@/app/ui/sangaku/FixedInputField";
+
+export function FixedInputFieldWrapper({ initial }: { initial: string[] }) {
+  const [fixedInputs, setFixedInputs] = useState(initial);
+  return (
+    <FixedInputField
+      fixedInputs={fixedInputs}
+      setFixedInputs={setFixedInputs}
+    />
+  );
+}

--- a/tests/components/sangaku/GenerateSourceUsageIndicator.spec.tsx
+++ b/tests/components/sangaku/GenerateSourceUsageIndicator.spec.tsx
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import GenerateSourceUsageIndicator from "@/app/ui/sangaku/generate-source-usage-indicator";
+
+test.describe("GenerateSourceUsageIndicator", () => {
+  test("shows placeholder when usage is undefined", async ({ mount }) => {
+    const component = await mount(
+      <GenerateSourceUsageIndicator usage={undefined} />,
+    );
+    await expect(
+      component.getByText("本日の残り生成回数: - / -"),
+    ).toBeVisible();
+  });
+
+  test("shows remaining count when usage is provided", async ({ mount }) => {
+    const component = await mount(
+      <GenerateSourceUsageIndicator
+        usage={{ used: 2, limit: 5, remaining: 3, reset_at: "2026-01-01" }}
+      />,
+    );
+    await expect(
+      component.getByText("本日の残り生成回数: 3 / 5"),
+    ).toBeVisible();
+  });
+
+  test("shows zero remaining when exhausted", async ({ mount }) => {
+    const component = await mount(
+      <GenerateSourceUsageIndicator
+        usage={{ used: 5, limit: 5, remaining: 0, reset_at: "2026-01-01" }}
+      />,
+    );
+    await expect(
+      component.getByText("本日の残り生成回数: 0 / 5"),
+    ).toBeVisible();
+  });
+});

--- a/tests/components/sangaku/UserSangaku.spec.tsx
+++ b/tests/components/sangaku/UserSangaku.spec.tsx
@@ -31,40 +31,39 @@ const sangaku: Sangaku = {
   },
 };
 
-// NOTE: server actionを含むためスキップ
-
-test.describe.skip("UserSangaku", () => {
+test.describe("UserSangaku", () => {
   test("has sangaku title", async ({ mount }) => {
     const component = await mount(<UserSangaku sangaku={sangaku} />);
     const title = component.getByRole("heading", { name: "test_title" });
     await expect(title).toBeVisible();
   });
 
-  test("has sangaku description", async ({ mount }) => {
-    const component = await mount(<UserSangaku sangaku={sangaku} />);
-    const description = component.getByRole("paragraph", { name: "test_desc" });
-    await expect(description).toBeVisible();
+  test("has sangaku description", async ({ mount, page }) => {
+    await mount(<UserSangaku sangaku={sangaku} />);
+    await expect(page.getByText("test_desc")).toBeVisible();
   });
 
-  test("has sangaku difficulty", async ({ mount }) => {
-    const component = await mount(<UserSangaku sangaku={sangaku} />);
-    const difficulty = component.getByRole("paragraph", { name: "普通" });
-    await expect(difficulty).toBeVisible();
+  test("has sangaku difficulty", async ({ mount, page }) => {
+    await mount(<UserSangaku sangaku={sangaku} />);
+    await expect(page.getByText("普通")).toBeVisible();
   });
 
-  test("has edit page link", async ({ mount }) => {
+  test("has edit page link", async ({ mount, page }) => {
     const component = await mount(<UserSangaku sangaku={sangaku} />);
     const menuButton = component.getByTestId("MoreVertIcon");
     await menuButton.click();
-    const editLink = component.getByRole("link", { name: "編集" });
+    // MUI Menu は Portal でレンダリングされるため page スコープで検索する
+    // MenuItem は component={NextLink} でも role="menuitem" が付与される
+    const editLink = page.getByRole("menuitem", { name: "編集" });
     await expect(editLink).toBeVisible();
   });
 
-  test("has delete button", async ({ mount }) => {
+  test("has delete button", async ({ mount, page }) => {
     const component = await mount(<UserSangaku sangaku={sangaku} />);
     const menuButton = component.getByTestId("MoreVertIcon");
     await menuButton.click();
-    const delteButton = component.getByRole("button", { name: "編集" });
-    await expect(delteButton).toBeVisible();
+    // MUI Menu は Portal でレンダリングされるため page スコープで検索する
+    const deleteButton = page.getByRole("menuitem", { name: "削除" });
+    await expect(deleteButton).toBeVisible();
   });
 });

--- a/tests/components/shared/Ema.spec.tsx
+++ b/tests/components/shared/Ema.spec.tsx
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import Ema from "@/app/ui/Ema";
+
+test.describe("Ema", () => {
+  test("renders children", async ({ mount }) => {
+    const component = await mount(<Ema width={18}>テストコンテンツ</Ema>);
+    await expect(component.getByText("テストコンテンツ")).toBeVisible();
+  });
+
+  test("renders with custom width", async ({ mount }) => {
+    const component = await mount(<Ema width={24}>コンテンツ</Ema>);
+    await expect(component.getByText("コンテンツ")).toBeVisible();
+  });
+});

--- a/tests/components/skeletons.spec.tsx
+++ b/tests/components/skeletons.spec.tsx
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import {
+  SangakuListSkeleton,
+  SangakuWithButtonListSkeleton,
+  MapSkeleton,
+} from "@/app/ui/skeletons";
+
+test.describe("SangakuListSkeleton", () => {
+  test("renders 9 skeleton items", async ({ mount, page }) => {
+    await mount(<SangakuListSkeleton />);
+    const skeletons = page.locator(".MuiSkeleton-root");
+    await expect(skeletons).toHaveCount(9);
+  });
+});
+
+test.describe("SangakuWithButtonListSkeleton", () => {
+  test("renders skeleton items with button skeletons", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SangakuWithButtonListSkeleton width={100} />);
+    // 9 cards * 2 skeletons (card + button) = 18
+    const skeletons = page.locator(".MuiSkeleton-root");
+    await expect(skeletons).toHaveCount(18);
+  });
+});
+
+test.describe("MapSkeleton", () => {
+  test("renders map skeleton", async ({ mount, page }) => {
+    await mount(<MapSkeleton />);
+    const skeletons = page.locator(".MuiSkeleton-root");
+    await expect(skeletons).toHaveCount(2);
+  });
+});


### PR DESCRIPTION
## 概要

Playwright Component Testing（`@playwright/experimental-ct-react`）でViteがNext.js固有の機能をバンドルできないため、21テスト（全31テストの68%）が `test.describe.skip()` でスキップされていた問題を解消しました。

**問題の原因:**
1. `"use server"` ファイル（`sangaku.ts`, `auth.ts` 等）をViteがバンドルできない
2. `useSession()` のセッションモックが不安定
3. `@mui/material-nextjs` が `next/navigation` から `useServerInsertedHTML` をインポートするがモックに未定義

**解消後の結果:** 51 passed / 1 skipped（意図的）

## 確認方法

```bash
cd front
pnpm test:components --project=chromium
# 51 passed, 1 skipped が表示されることを確認
```

## 影響範囲

- テストコード・テスト設定のみ変更。プロダクションコードへの影響なし。
- `playwright-ct.config.ts` のViteエイリアス設定
- `playwright/index.tsx` の `hooksConfig` 対応
- `tests/__mocks__/` 配下のスタブファイル群
- `tests/components/` 配下のスペックファイル

## チェックリスト

- [ ] siderをパスした
- [x] コンポーネントテストをパスした（51 passed, 1 skipped）
- [ ] Lint のチェックをパスした
- [x] ユニットテストをパスした

## コメント

- Server Actionsのモック方式はViteエイリアスで対応。プロダクションコードを変更せずに済みます。
- `useServerInsertedHTML` は `@mui/material-nextjs` の内部依存で呼ばれるため、ナビゲーションモックに空実装を追加しました。
- モバイルのドロワー開閉テスト（`ResponsiveNav.spec.tsx`）は引き続き意図的スキップ済みです（E2Eテストで代替）。