### PR TITLE
fix: MarkdownEditorで改行増加時にスタイルが崩れる問題を修正

### DIFF
--- a/app/ui/shared/MarkdownEditor.tsx
+++ b/app/ui/shared/MarkdownEditor.tsx
@@ -77,6 +77,11 @@ export default function MarkdownEditor({
               ...panelSx,
               alignItems: "flex-start",
             },
+            "& .MuiInputBase-input": {
+              height: "100% !important",
+              overflowY: "auto !important",
+              boxSizing: "border-box",
+            },
           }}
         />
       ) : (
@@ -86,7 +91,7 @@ export default function MarkdownEditor({
             border: 1,
             borderColor: "rgba(0,0,0,0.23)",
             borderRadius: "4px",
-            p: 2,
+            p: 1,
           }}
         >
           {value ? (


### PR DESCRIPTION
## 概要

算額作成・編集ページの問題文入力エリア（`MarkdownEditor`）で、改行を増やすとスタイルが崩れる問題を修正しました。

**原因:**
MUI の multiline TextField は auto-resize のため、`textarea` に `style="overflow: hidden"` を JavaScript で動的に設定します。これにより、コンテナの `overflowY: auto` が無効化され、`textarea` がコンテナ外にはみ出てレイアウトが崩れていました。

**修正内容:**
- `.MuiInputBase-input` に `height: 100% !important` / `overflowY: auto !important` を追加し、MUI の inline style を上書き
- プレビューエリアの padding を `p: 2` → `p: 1` に縮小

## 確認方法

1. 算額作成ページ（`/sangakus/new`）または編集ページを開く
2. 問題文入力エリアに改行を繰り返し入力する
3. テキストエリアが `22.5rem` の高さを超えた際、外側レイアウトが崩れずテキストエリア内でスクロールされることを確認する
4. プレビュータブに切り替えて padding が適切に表示されることを確認する

## 影響範囲

- `app/ui/shared/MarkdownEditor.tsx`
- 算額作成ページ・編集ページの問題文入力エリアのみ

## チェックリスト

- [ ] siderをパスした
- [ ] インテグレーションテストを追加した
- [ ] Lint のチェックをパスした
- [ ] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した

## コメント

MUI の `!important` による inline style 上書きはやや強引ですが、MUI の auto-resize 機構を無効化せずにスクロールを有効化する最小限の対処です。