### PR TITLE
feat: フロントエンド起源証明（X-Client-Secretヘッダー付与）の実装

### DIFF
--- a/app/lib/actions/answer.ts
+++ b/app/lib/actions/answer.ts
@@ -6,6 +6,7 @@ import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { setFlash } from "@/app/lib/actions/flash";
 import { customSignOut } from "./auth";
 import { redirect } from "next/navigation";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -19,11 +20,6 @@ export type State = {
 export const createAnswer = async (sangaku_id: string, source: string) => {
   const session = await auth();
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
-
   const params = {
     source,
   };
@@ -33,7 +29,7 @@ export const createAnswer = async (sangaku_id: string, source: string) => {
       `${apiUrl}/api/v1/user/sangakus/${sangaku_id}/answers`,
       {
         method: "POST",
-        headers,
+        headers: buildHeaders(session?.accessToken),
         body: JSON.stringify(params),
       },
     );

--- a/app/lib/actions/auth.ts
+++ b/app/lib/actions/auth.ts
@@ -3,20 +3,17 @@
 import { auth, signOut } from "@/auth";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { setFlash } from "./flash";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
 export async function customSignOut() {
   const session = await auth();
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
 
   try {
     await fetch(`${apiUrl}/api/v1/authenticate`, {
       method: "DELETE",
-      headers,
+      headers: buildHeaders(session?.accessToken),
     });
     await setFlash({ type: "success", message: "サインアウトしました" });
     await signOut({ redirectTo: "/signin" });

--- a/app/lib/actions/profile.ts
+++ b/app/lib/actions/profile.ts
@@ -6,6 +6,7 @@ import { redirect } from "next/navigation";
 import { setFlash } from "@/app/lib/actions/flash";
 import { customSignOut } from "./auth";
 import { User } from "../definitions";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -25,11 +26,6 @@ export const updateProfile = async (_prevState: State, formData: FormData) => {
 
   const nickname = formData.get("nickname");
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
-
   const params = {
     user: { nickname },
   };
@@ -37,7 +33,7 @@ export const updateProfile = async (_prevState: State, formData: FormData) => {
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/profile`, {
       method: "PATCH",
-      headers,
+      headers: buildHeaders(session?.accessToken),
       body: JSON.stringify(params),
     });
 

--- a/app/lib/actions/sangaku.ts
+++ b/app/lib/actions/sangaku.ts
@@ -7,6 +7,7 @@ import { redirect } from "next/navigation";
 import { setFlash } from "@/app/lib/actions/flash";
 import { Difficulty, GenerateSourceUsage } from "../definitions";
 import { customSignOut } from "./auth";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -35,10 +36,6 @@ export const createSangaku = async (
   const session = await auth();
   const title = formData.get("title");
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
   const params = {
     sangaku: {
       title,
@@ -52,7 +49,7 @@ export const createSangaku = async (
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/sangakus`, {
       method: "POST",
-      headers,
+      headers: buildHeaders(session?.accessToken),
       body: JSON.stringify(params),
     });
 
@@ -109,10 +106,6 @@ export const updateSangaku = async (
 
   const title = formData.get("title");
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
   const params = {
     sangaku: {
       title,
@@ -126,7 +119,7 @@ export const updateSangaku = async (
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/sangakus/${id}`, {
       method: "PATCH",
-      headers,
+      headers: buildHeaders(session?.accessToken),
       body: JSON.stringify(params),
     });
 
@@ -172,15 +165,11 @@ export const updateSangaku = async (
 
 export const deleteSangaku = async (id: string) => {
   const session = await auth();
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
 
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/sangakus/${id}`, {
       method: "DELETE",
-      headers,
+      headers: buildHeaders(session?.accessToken),
     });
 
     switch (res.status) {
@@ -315,10 +304,7 @@ export const generateSource = async (
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/sangakus/generate_source`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${session?.accessToken}`,
-      },
+      headers: buildHeaders(session?.accessToken),
       body: JSON.stringify({ description }),
     });
 

--- a/app/lib/actions/shrine.ts
+++ b/app/lib/actions/shrine.ts
@@ -5,6 +5,7 @@ import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { setFlash } from "./flash";
 import { revalidatePath } from "next/cache";
 import { customSignOut } from "./auth";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -14,11 +15,6 @@ export async function dedicateSangaku(
   location: { lat: number; lng: number },
 ) {
   const session = await auth();
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
-
   const params = { shrine_id, ...location };
 
   try {
@@ -26,7 +22,7 @@ export async function dedicateSangaku(
       `${apiUrl}/api/v1/user/sangakus/${sangaku_id}/dedicate`,
       {
         method: "POST",
-        headers,
+        headers: buildHeaders(session?.accessToken),
         body: JSON.stringify(params),
       },
     );
@@ -63,15 +59,11 @@ export async function createSangakuSave(sangaku_id: string) {
     setFlash({ type: "error", message: "サインインしてください" });
     return null;
   }
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
 
   try {
     const res = await fetch(`${apiUrl}/api/v1/sangakus/${sangaku_id}/save`, {
       method: "POST",
-      headers,
+      headers: buildHeaders(session?.accessToken),
     });
 
     switch (res.status) {

--- a/app/lib/client_headers.ts
+++ b/app/lib/client_headers.ts
@@ -1,0 +1,16 @@
+export function buildHeaders(accessToken?: string | null): Record<string, string> {
+  const clientSecret = process.env.CLIENT_SECRET ?? null;
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (clientSecret !== null) {
+    headers["X-Client-Secret"] = clientSecret;
+  }
+
+  if (accessToken) {
+    headers["Authorization"] = `Bearer ${accessToken}`;
+  }
+  return headers;
+}

--- a/app/lib/data/answer.ts
+++ b/app/lib/data/answer.ts
@@ -3,20 +3,16 @@
 import { auth } from "@/auth";
 import type { Answer, AnswerResult } from "../definitions";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
 export const fetchUserAnswer = async (id: string) => {
   const session = await auth();
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
-
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/answers/${id}`, {
-      headers,
+      headers: buildHeaders(session?.accessToken),
     });
 
     switch (res.status) {
@@ -40,16 +36,11 @@ export const fetchUserAnswer = async (id: string) => {
 export const fetchUserAnswerWithSangakuId = async (sangaku_id: string) => {
   const session = await auth();
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
-
   try {
     const res = await fetch(
       `${apiUrl}/api/v1/user/saved_sangakus/${sangaku_id}/answer`,
       {
-        headers,
+        headers: buildHeaders(session?.accessToken),
       },
     );
 
@@ -74,15 +65,10 @@ export const fetchUserAnswerWithSangakuId = async (sangaku_id: string) => {
 export const fetchUserAnswerResult = async (id: string) => {
   const session = await auth();
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
-
   try {
     while (true) {
       const res = await fetch(`${apiUrl}/api/v1/user/answer_results/${id}`, {
-        headers,
+        headers: buildHeaders(session?.accessToken),
         cache: "no-store",
       });
 

--- a/app/lib/data/sangaku.ts
+++ b/app/lib/data/sangaku.ts
@@ -2,7 +2,12 @@
 
 import { auth } from "@/auth";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
-import type { Sangaku, SangakuResult, GenerateSourceUsage } from "../definitions";
+import type {
+  Sangaku,
+  SangakuResult,
+  GenerateSourceUsage,
+} from "../definitions";
+import { buildHeaders } from "@/app/lib/client_headers";
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export async function fetchUserSangakus(
@@ -11,11 +16,6 @@ export async function fetchUserSangakus(
   shrine_id: "" | "any" | number,
 ): Promise<{ sangakus: Sangaku[]; totalPage: number; message?: string }> {
   const session = await auth();
-
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
 
   const params = new URLSearchParams();
   params.set("page", page);
@@ -34,7 +34,7 @@ export async function fetchUserSangakus(
     const res = await fetch(
       `${apiUrl}/api/v1/user/sangakus?${params.toString()}`,
       {
-        headers,
+        headers: buildHeaders(session?.accessToken),
       },
     );
 
@@ -62,7 +62,6 @@ export async function fetchUserSangakus(
     if (isRedirectError(error)) {
       throw error;
     } else {
-      console.log(error);
       return {
         sangakus: [],
         totalPage: 0,
@@ -75,14 +74,9 @@ export async function fetchUserSangakus(
 export async function fetchUserSangaku(id: string) {
   const session = await auth();
 
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
-
   try {
     const res = await fetch(`${apiUrl}/api/v1/user/sangakus/${id}`, {
-      headers,
+      headers: buildHeaders(session?.accessToken),
     });
 
     switch (res.status) {
@@ -110,16 +104,12 @@ export async function fetchShrineSangakus(
   difficulty: string,
 ): Promise<{ sangakus: Sangaku[]; totalPage: number; message?: string }> {
   try {
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-    };
-
     const params = new URLSearchParams({ page, title: query, difficulty });
 
     const res = await fetch(
       `${apiUrl}/api/v1/shrines/${shrine_id}/sangakus?${params}`,
       {
-        headers,
+        headers: buildHeaders(),
       },
     );
 
@@ -153,11 +143,6 @@ export async function fetchSavedSangakus(
   const session = await auth();
 
   try {
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${session?.accessToken}`,
-    };
-
     const params = new URLSearchParams({ page, title: query, difficulty });
 
     if (type) {
@@ -165,7 +150,7 @@ export async function fetchSavedSangakus(
     }
 
     const res = await fetch(`${apiUrl}/api/v1/user/saved_sangakus?${params}`, {
-      headers,
+      headers: buildHeaders(session?.accessToken),
     });
 
     switch (res.status) {
@@ -204,11 +189,6 @@ export async function fetchSavedSangaku(
   const session = await auth();
 
   try {
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${session?.accessToken}`,
-    };
-
     const params = new URLSearchParams();
     if (type) {
       params.set("type", type);
@@ -217,7 +197,7 @@ export async function fetchSavedSangaku(
     const res = await fetch(
       `${apiUrl}/api/v1/user/saved_sangakus/${id}?${params}`,
       {
-        headers,
+        headers: buildHeaders(session?.accessToken),
       },
     );
 
@@ -237,18 +217,15 @@ export async function fetchSavedSangaku(
   }
 }
 
-export async function fetchGenerateSourceUsage(): Promise<GenerateSourceUsage | undefined> {
+export async function fetchGenerateSourceUsage(): Promise<
+  GenerateSourceUsage | undefined
+> {
   const session = await auth();
-
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session?.accessToken}`,
-  };
 
   try {
     const res = await fetch(
       `${apiUrl}/api/v1/user/sangakus/generate_source_usage`,
-      { headers },
+      { headers: buildHeaders(session?.accessToken) },
     );
 
     switch (res.status) {
@@ -273,13 +250,8 @@ export async function fetchUserSangakuResult(id: string) {
   const session = await auth();
 
   try {
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${session?.accessToken}`,
-    };
-
     const res = await fetch(`${apiUrl}/api/v1/user/sangakus/${id}/result`, {
-      headers,
+      headers: buildHeaders(session?.accessToken),
     });
 
     switch (res.status) {

--- a/app/lib/data/shrine.ts
+++ b/app/lib/data/shrine.ts
@@ -2,6 +2,7 @@
 
 import { setFlash } from "../actions/flash";
 import { Shrine } from "../definitions";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -12,16 +13,13 @@ export async function fetchShrines(
   highLng: string,
 ) {
   try {
-    const headers: HeadersInit = {
-      "Content-Type": "application/json",
-    };
     const params = new URLSearchParams({ searchType: "Map" });
     params.set("lowLat", lowLat);
     params.set("highLat", highLat);
     params.set("lowLng", lowLng);
     params.set("highLng", highLng);
 
-    const res = await fetch(`${apiUrl}/api/v1/shrines?${params}`, { headers });
+    const res = await fetch(`${apiUrl}/api/v1/shrines?${params}`, { headers: buildHeaders() });
 
     if (res.status == 200) {
       const data = await res.json();
@@ -37,13 +35,9 @@ export async function fetchShrines(
 }
 
 export async function fetchShrine(id: string) {
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
-
   try {
     const res = await fetch(`${apiUrl}/api/v1/shrines/${id}`, {
-      headers,
+      headers: buildHeaders(),
     });
 
     if (res.status == 200) {

--- a/auth.ts
+++ b/auth.ts
@@ -5,6 +5,7 @@ import type { Provider } from "next-auth/providers";
 import Credentials from "next-auth/providers/credentials";
 
 import { setFlash } from "@/app/lib/actions/flash";
+import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
@@ -68,7 +69,7 @@ export const { handlers, signIn, signOut, auth, unstable_update } = NextAuth({
       try {
         const response = await fetch(`${apiUrl}/api/v1/authenticate`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: buildHeaders(),
           body: JSON.stringify({ token: idToken }),
         });
 


### PR DESCRIPTION
## 概要

バックエンドAPIへのフロントエンド起源証明として、全バックエンドAPIリクエストに `X-Client-Secret` ヘッダーを自動付与する実装です。

関連Issue: Alnoir-0011/algo_sangaku_front#66
関連バックエンドIssue: https://github.com/Alnoir-0011/algo_sangaku_back/issues/220

## 確認方法

1. `.env` に `CLIENT_SECRET=<back/.envと同じ値>` を追加してください
2. バックエンド・フロントエンドを起動し、各APIリクエストのヘッダーに `X-Client-Secret` が付与されていることをDevToolsのネットワークタブで確認してください

## 影響範囲

- `auth.ts` — サインイン時のfetch
- `app/lib/actions/` 配下の全actions（answer / auth / profile / shrine / sangaku）
- `app/lib/data/` 配下の全data（answer / sangaku / shrine）
- paiza.io外部APIへのリクエストは対象外

## チェックリスト

- [x] siderをパスした
- [x] インテグレーションテストを追加した
- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした
- [x] 必要なドキュメントを作成した

## コメント

- `CLIENT_SECRET` は `NEXT_PUBLIC_` プレフィックスなしのため、ブラウザには公開されません
- `CLIENT_SECRET` が未設定の場合は `null` として扱い、`X-Client-Secret` ヘッダーを除外します（アプリはクラッシュしません）
- `.env.example` への追記はルートディレクトリへの書き込み権限の制限により手動対応が必要です