### PR TITLE
feat: ユーザープロフィール画面の実装

### DIFF
--- a/app/lib/actions/answer.ts
+++ b/app/lib/actions/answer.ts
@@ -8,7 +8,7 @@ import { customSignOut } from "./auth";
 import { redirect } from "next/navigation";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+const apiUrl = process.env.API_URL!;
 
 export type State = {
   errors?: {

--- a/app/lib/actions/auth.ts
+++ b/app/lib/actions/auth.ts
@@ -5,7 +5,7 @@ import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { setFlash } from "./flash";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+const apiUrl = process.env.API_URL!;
 
 export async function customSignOut() {
   const session = await auth();

--- a/app/lib/actions/profile.ts
+++ b/app/lib/actions/profile.ts
@@ -2,13 +2,14 @@
 
 import { auth, unstable_update } from "@/auth";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
+import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { setFlash } from "@/app/lib/actions/flash";
 import { customSignOut } from "./auth";
 import { User } from "../definitions";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+const apiUrl = process.env.API_URL!;
 
 export type State = {
   errors?: {
@@ -24,7 +25,8 @@ export const updateProfile = async (_prevState: State, formData: FormData) => {
   const session = await auth();
   const user = session?.user;
 
-  const nickname = formData.get("nickname");
+  const raw = formData.get("nickname");
+  const nickname = typeof raw === "string" ? raw : undefined;
 
   const params = {
     user: { nickname },
@@ -46,7 +48,8 @@ export const updateProfile = async (_prevState: State, formData: FormData) => {
           type: "success",
           message: "プロフィールを更新しました",
         });
-        redirect("/");
+        revalidatePath("/user/profile");
+        redirect("/user/profile");
       case 401:
         await setFlash({
           type: "error",
@@ -58,15 +61,16 @@ export const updateProfile = async (_prevState: State, formData: FormData) => {
       case 400:
         const data = await res.json();
         await setFlash({ type: "error", message: "入力に誤りがあります" });
+        const errors = Array.isArray(data.errors)
+          ? Object.fromEntries(data.errors)
+          : {};
         return {
-          errors: Object.fromEntries(data.errors),
-          // message: "入力に誤りがあります",
+          errors,
           values: { nickname },
         } as State;
       default:
         await setFlash({ type: "error", message: "リクエストに失敗しました" });
         return {
-          // message: "リクエストに失敗しました",
           values: { nickname },
         } as State;
     }
@@ -76,8 +80,37 @@ export const updateProfile = async (_prevState: State, formData: FormData) => {
     }
     await setFlash({ type: "error", message: "予期せぬエラーが発生しました" });
     return {
-      // message: "予期せぬエラーが発生しました",
       values: { nickname },
     } as State;
+  }
+};
+
+export const updateShowAnswerCount = async (
+  showAnswerCount: boolean,
+): Promise<{ success: boolean }> => {
+  const session = await auth();
+
+  try {
+    const res = await fetch(`${apiUrl}/api/v1/user/profile`, {
+      method: "PATCH",
+      headers: buildHeaders(session?.accessToken),
+      body: JSON.stringify({ user: { show_answer_count: showAnswerCount } }),
+    });
+
+    if (res.status === 200) {
+      await setFlash({ type: "success", message: "プライバシー設定を更新しました" });
+      return { success: true };
+    }
+    if (res.status === 401) {
+      await customSignOut();
+    }
+    await setFlash({ type: "error", message: "設定の更新に失敗しました" });
+    return { success: false };
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    }
+    await setFlash({ type: "error", message: "予期せぬエラーが発生しました" });
+    return { success: false };
   }
 };

--- a/app/lib/actions/sangaku.ts
+++ b/app/lib/actions/sangaku.ts
@@ -9,7 +9,7 @@ import { Difficulty, GenerateSourceUsage } from "../definitions";
 import { customSignOut } from "./auth";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+const apiUrl = process.env.API_URL!;
 
 export type State = {
   errors?: {

--- a/app/lib/actions/shrine.ts
+++ b/app/lib/actions/shrine.ts
@@ -7,7 +7,7 @@ import { revalidatePath } from "next/cache";
 import { customSignOut } from "./auth";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+const apiUrl = process.env.API_URL!;
 
 export async function dedicateSangaku(
   shrine_id: string,

--- a/app/lib/data/answer.ts
+++ b/app/lib/data/answer.ts
@@ -5,7 +5,7 @@ import type { Answer, AnswerResult } from "../definitions";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+const apiUrl = process.env.API_URL!;
 
 export const fetchUserAnswer = async (id: string) => {
   const session = await auth();

--- a/app/lib/data/profile.ts
+++ b/app/lib/data/profile.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { auth } from "@/auth";
+import { MyProfile, PublicProfile } from "../definitions";
+import { buildHeaders } from "@/app/lib/client_headers";
+
+const apiUrl = process.env.API_URL!;
+
+export async function fetchMyProfile(): Promise<MyProfile | undefined> {
+  const session = await auth();
+
+  try {
+    const res = await fetch(`${apiUrl}/api/v1/user/profile`, {
+      headers: buildHeaders(session?.accessToken),
+    });
+
+    if (res.status === 200) {
+      const body = await res.json();
+      return body.data as MyProfile;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetchPublicProfile(
+  id: string,
+): Promise<PublicProfile | undefined> {
+  if (!/^\d+$/.test(id)) {
+    return undefined;
+  }
+
+  try {
+    const res = await fetch(`${apiUrl}/api/v1/profiles/${id}`, {
+      headers: buildHeaders(),
+    });
+
+    if (res.status === 200) {
+      const body = await res.json();
+      return body.data as PublicProfile;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/app/lib/data/sangaku.ts
+++ b/app/lib/data/sangaku.ts
@@ -8,7 +8,7 @@ import type {
   GenerateSourceUsage,
 } from "../definitions";
 import { buildHeaders } from "@/app/lib/client_headers";
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 export async function fetchUserSangakus(
   page: string,

--- a/app/lib/data/shrine.ts
+++ b/app/lib/data/shrine.ts
@@ -4,7 +4,7 @@ import { setFlash } from "../actions/flash";
 import { Shrine } from "../definitions";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+const apiUrl = process.env.API_URL!;
 
 export async function fetchShrines(
   lowLat: string,

--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -25,7 +25,7 @@ export type Sangaku = {
   };
 };
 
-export type Difficulty = "easy" | "nomal" | "difficult" | "very_difficult";
+export type Difficulty = "easy" | "normal" | "difficult" | "very_difficult";
 
 type input = {
   id: number;
@@ -112,4 +112,36 @@ export type GenerateSourceUsage = {
   limit: number;
   remaining: number;
   reset_at: string;
+};
+
+export type MyProfile = {
+  id: string;
+  type: "my_profile";
+  attributes: {
+    email: string;
+    nickname: string;
+    show_answer_count: boolean;
+    created_at: string;
+    sangaku_count: number;
+    dedicated_sangaku_count: number;
+    saved_sangaku_count: number;
+    answer_count: number;
+  };
+};
+
+export type PublicProfile = {
+  id: string;
+  type: "profile";
+  attributes: {
+    nickname: string;
+    created_at: string;
+    sangaku_count: number;
+    dedicated_sangaku_count: number;
+    answer_count: number | null;
+    dedicated_sangakus: {
+      id: number;
+      title: string;
+      shrine_name: string;
+    }[];
+  };
 };

--- a/app/profiles/[id]/page.tsx
+++ b/app/profiles/[id]/page.tsx
@@ -1,0 +1,71 @@
+import { Avatar, Box, Paper, Typography } from "@mui/material";
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { fetchPublicProfile } from "@/app/lib/data/profile";
+import ActivitySummary from "@/app/ui/profile/activity-summary";
+import DedicatedSangakuList from "@/app/ui/profile/dedicated-sangaku-list";
+
+export const metadata: Metadata = {
+  title: "プロフィール",
+};
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function Page({ params }: Props) {
+  const { id } = await params;
+  const profile = await fetchPublicProfile(id);
+
+  if (!profile) {
+    notFound();
+  }
+
+  const { attributes } = profile;
+  const initial = attributes.nickname.charAt(0).toUpperCase() || "?";
+
+  return (
+    <Box maxWidth={640} mx="auto">
+      <Typography variant="h4" component="h1" mb={3}>
+        プロフィール
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+        {/* アバター + 基本情報 */}
+        <Box display="flex" alignItems="center" gap={2} mb={2}>
+          <Avatar
+            sx={{
+              width: 72,
+              height: 72,
+              fontSize: "2rem",
+              bgcolor: "primary.main",
+            }}
+          >
+            {initial}
+          </Avatar>
+          <Box>
+            <Typography variant="h6">{attributes.nickname}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              登録日:{" "}
+              {new Date(attributes.created_at).toLocaleDateString("ja-JP")}
+            </Typography>
+          </Box>
+        </Box>
+      </Paper>
+
+      {/* 活動サマリー */}
+      <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+        <ActivitySummary
+          sangakuCount={attributes.sangaku_count}
+          dedicatedSangakuCount={attributes.dedicated_sangaku_count}
+          answerCount={attributes.answer_count}
+        />
+      </Paper>
+
+      {/* 奉納済み算額一覧 */}
+      <Paper variant="outlined" sx={{ p: 3 }}>
+        <DedicatedSangakuList sangakus={attributes.dedicated_sangakus} />
+      </Paper>
+    </Box>
+  );
+}

--- a/app/ui/Search.tsx
+++ b/app/ui/Search.tsx
@@ -76,7 +76,7 @@ export default function Search({ placeholder, difficulty }: Props) {
           >
             <MenuItem value="">全て</MenuItem>
             <MenuItem value="easy">簡単</MenuItem>
-            <MenuItem value="nomal">普通</MenuItem>
+            <MenuItem value="normal">普通</MenuItem>
             <MenuItem value="difficult">難しい</MenuItem>
             <MenuItem value="very_difficult">とても難しい</MenuItem>
           </Select>

--- a/app/ui/profile/activity-summary.tsx
+++ b/app/ui/profile/activity-summary.tsx
@@ -1,0 +1,51 @@
+import { Box, Card, CardContent, Typography } from "@mui/material";
+
+interface StatCardProps {
+  label: string;
+  value: number | null;
+}
+
+function StatCard({ label, value }: StatCardProps) {
+  return (
+    <Card variant="outlined" sx={{ flex: 1, minWidth: 100 }}>
+      <CardContent sx={{ textAlign: "center", py: 2, "&:last-child": { pb: 2 } }}>
+        <Typography variant="h5" component="p" fontWeight="bold">
+          {value === null ? "—" : value}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {label}
+        </Typography>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface Props {
+  sangakuCount: number;
+  dedicatedSangakuCount: number;
+  answerCount: number | null;
+  savedSangakuCount?: number;
+}
+
+export default function ActivitySummary({
+  sangakuCount,
+  dedicatedSangakuCount,
+  answerCount,
+  savedSangakuCount,
+}: Props) {
+  return (
+    <Box>
+      <Typography variant="subtitle1" fontWeight="bold" mb={1}>
+        活動サマリー
+      </Typography>
+      <Box display="flex" gap={1} flexWrap="wrap">
+        <StatCard label="作成した算額" value={sangakuCount} />
+        <StatCard label="奉納済み算額" value={dedicatedSangakuCount} />
+        {savedSangakuCount !== undefined && (
+          <StatCard label="保存した算額" value={savedSangakuCount} />
+        )}
+        <StatCard label="提出した回答" value={answerCount} />
+      </Box>
+    </Box>
+  );
+}

--- a/app/ui/profile/dedicated-sangaku-list.tsx
+++ b/app/ui/profile/dedicated-sangaku-list.tsx
@@ -1,11 +1,6 @@
-import {
-  Box,
-  Divider,
-  List,
-  ListItem,
-  ListItemText,
-  Typography,
-} from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import Grid from "@mui/material/Grid2";
+import Ema from "@/app/ui/Ema";
 
 interface DedicatedSangaku {
   id: number;
@@ -28,19 +23,45 @@ export default function DedicatedSangakuList({ sangakus }: Props) {
           奉納済みの算額はありません
         </Typography>
       ) : (
-        <List disablePadding>
-          {sangakus.map((sangaku, index) => (
-            <Box key={sangaku.id}>
-              {index > 0 && <Divider />}
-              <ListItem disableGutters>
-                <ListItemText
-                  primary={sangaku.title}
-                  secondary={sangaku.shrine_name}
-                />
-              </ListItem>
-            </Box>
+        <Grid container spacing={2} sx={{ justifyContent: "center", mt: 1 }}>
+          {sangakus.map((sangaku) => (
+            <Grid key={sangaku.id}>
+              <Ema width={12}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    height: "100%",
+                    flexDirection: "column",
+                    justifyContent: "center",
+                    alignItems: "center",
+                  }}
+                >
+                  <Typography
+                    variant="body1"
+                    fontWeight="bold"
+                    sx={{
+                      textAlign: "center",
+                      overflow: "hidden",
+                      display: "-webkit-box",
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: "vertical",
+                      textOverflow: "ellipsis",
+                    }}
+                  >
+                    {sangaku.title}
+                  </Typography>
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    sx={{ textAlign: "center", mt: 1 }}
+                  >
+                    {sangaku.shrine_name}
+                  </Typography>
+                </Box>
+              </Ema>
+            </Grid>
           ))}
-        </List>
+        </Grid>
       )}
     </Box>
   );

--- a/app/ui/profile/dedicated-sangaku-list.tsx
+++ b/app/ui/profile/dedicated-sangaku-list.tsx
@@ -1,0 +1,47 @@
+import {
+  Box,
+  Divider,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+} from "@mui/material";
+
+interface DedicatedSangaku {
+  id: number;
+  title: string;
+  shrine_name: string;
+}
+
+interface Props {
+  sangakus: DedicatedSangaku[];
+}
+
+export default function DedicatedSangakuList({ sangakus }: Props) {
+  return (
+    <Box>
+      <Typography variant="subtitle1" fontWeight="bold" mb={1}>
+        奉納済み算額
+      </Typography>
+      {sangakus.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          奉納済みの算額はありません
+        </Typography>
+      ) : (
+        <List disablePadding>
+          {sangakus.map((sangaku, index) => (
+            <Box key={sangaku.id}>
+              {index > 0 && <Divider />}
+              <ListItem disableGutters>
+                <ListItemText
+                  primary={sangaku.title}
+                  secondary={sangaku.shrine_name}
+                />
+              </ListItem>
+            </Box>
+          ))}
+        </List>
+      )}
+    </Box>
+  );
+}

--- a/app/ui/profile/nickname-form.tsx
+++ b/app/ui/profile/nickname-form.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Box, Button, TextField, Typography } from "@mui/material";
+import { useActionState } from "react";
+import { updateProfile, State } from "@/app/lib/actions/profile";
+
+interface Props {
+  nickname: string;
+}
+
+export default function NicknameForm({ nickname }: Props) {
+  const initialState: State = { values: { nickname } };
+  const [state, formAction, isPending] = useActionState(
+    updateProfile,
+    initialState,
+  );
+
+  return (
+    <form action={formAction}>
+      <Box display="flex" gap={1} alignItems="flex-start">
+        <Box flex={1}>
+          <TextField
+            required
+            fullWidth
+            label="ニックネーム"
+            name="nickname"
+            size="small"
+            defaultValue={state.values?.nickname ?? nickname}
+          />
+          {state.errors?.nickname &&
+            state.errors.nickname.map((error: string) => (
+              <Typography
+                aria-label="nicknameError"
+                key={error}
+                variant="caption"
+                sx={{ color: "error.main" }}
+              >
+                {error}
+              </Typography>
+            ))}
+        </Box>
+        <Button
+          variant="contained"
+          type="submit"
+          size="small"
+          disabled={isPending}
+          sx={{ mt: 0.5 }}
+        >
+          保存
+        </Button>
+      </Box>
+    </form>
+  );
+}

--- a/app/ui/profile/privacy-settings-card.tsx
+++ b/app/ui/profile/privacy-settings-card.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {
+  Box,
+  FormControlLabel,
+  Switch,
+  Typography,
+} from "@mui/material";
+import { useState, useTransition } from "react";
+import { updateShowAnswerCount } from "@/app/lib/actions/profile";
+
+interface Props {
+  showAnswerCount: boolean;
+}
+
+export default function PrivacySettingsCard({ showAnswerCount }: Props) {
+  const [checked, setChecked] = useState(showAnswerCount);
+  const [isPending, startTransition] = useTransition();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = e.target.checked;
+    setChecked(next);
+    startTransition(async () => {
+      const result = await updateShowAnswerCount(next);
+      if (!result.success) {
+        setChecked(!next);
+      }
+    });
+  };
+
+  return (
+    <Box>
+      <Typography variant="subtitle1" fontWeight="bold" mb={1}>
+        プライバシー設定
+      </Typography>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={checked}
+            onChange={handleChange}
+            disabled={isPending}
+          />
+        }
+        label="提出した回答数を公開プロフィールに表示する"
+      />
+    </Box>
+  );
+}

--- a/app/ui/sangaku/create-form.tsx
+++ b/app/ui/sangaku/create-form.tsx
@@ -39,7 +39,7 @@ export default function Page({ initialUsage }: Props) {
   const [source, setSource] = useState(initialSource);
   const [description, setDescription] = useState("");
   const [fixedInputs, setFixedInputs] = useState([""]);
-  const [difficulty, setDifficulty] = useState<Difficulty>("nomal");
+  const [difficulty, setDifficulty] = useState<Difficulty>("normal");
   const [modalOpen, setModalOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [usage, setUsage] = useState<GenerateSourceUsage | undefined>(initialUsage);
@@ -229,7 +229,7 @@ export default function Page({ initialUsage }: Props) {
                 onChange={handleDifficultyChange}
               >
                 <MenuItem value={"easy"}>簡単</MenuItem>
-                <MenuItem value={"nomal"}>普通</MenuItem>
+                <MenuItem value={"normal"}>普通</MenuItem>
                 <MenuItem value={"difficult"}>難しい</MenuItem>
                 <MenuItem value={"very_difficult"}>とても難しい</MenuItem>
               </Select>

--- a/app/ui/sangaku/edit-form.tsx
+++ b/app/ui/sangaku/edit-form.tsx
@@ -241,7 +241,7 @@ export default function Form({ sangaku, initialUsage }: Props) {
                 onChange={handleDifficultyChange}
               >
                 <MenuItem value={"easy"}>簡単</MenuItem>
-                <MenuItem value={"nomal"}>普通</MenuItem>
+                <MenuItem value={"normal"}>普通</MenuItem>
                 <MenuItem value={"difficult"}>難しい</MenuItem>
                 <MenuItem value={"very_difficult"}>とても難しい</MenuItem>
               </Select>

--- a/app/ui/shrine/dedicate/Sangaku.tsx
+++ b/app/ui/shrine/dedicate/Sangaku.tsx
@@ -11,7 +11,7 @@ export default function SangakuComponent({ data, handleClick }: Props) {
     switch (str) {
       case "easy":
         return "簡単";
-      case "nomal":
+      case "normal":
         return "普通";
       default:
         return "難しい";

--- a/app/ui/utility.ts
+++ b/app/ui/utility.ts
@@ -2,7 +2,7 @@ export const difficultyTranslation = (str: string) => {
   switch (str) {
     case "easy":
       return "簡単";
-    case "nomal":
+    case "normal":
       return "普通";
     case "difficult":
       return "難しい";

--- a/app/user/profile/page.tsx
+++ b/app/user/profile/page.tsx
@@ -1,21 +1,118 @@
-import Form from "@/app/ui/profile/edit-form";
 import { auth } from "@/auth";
-import { Box, Typography } from "@mui/material";
+import { Avatar, Box, Divider, Paper, Typography } from "@mui/material";
 import { Metadata } from "next";
+import { fetchMyProfile } from "@/app/lib/data/profile";
+import { fetchGenerateSourceUsage } from "@/app/lib/data/sangaku";
+import NicknameForm from "@/app/ui/profile/nickname-form";
+import ActivitySummary from "@/app/ui/profile/activity-summary";
+import PrivacySettingsCard from "@/app/ui/profile/privacy-settings-card";
 
 export const metadata: Metadata = {
-  title: "プロフィール編集",
+  title: "マイページ",
 };
 
 export default async function Page() {
-  const session = await auth();
+  const [session, profile, usage] = await Promise.all([
+    auth(),
+    fetchMyProfile(),
+    fetchGenerateSourceUsage(),
+  ]);
+
+  const nickname = profile?.attributes.nickname ?? session?.user?.nickname ?? "";
+  const initial = nickname.charAt(0).toUpperCase() || "?";
 
   return (
-    <Box>
-      <Typography variant="h4" component="h1" mb={2}>
-        プロフィール編集
+    <Box maxWidth={640} mx="auto">
+      <Typography variant="h4" component="h1" mb={3}>
+        マイページ
       </Typography>
-      <Form user={session!.user!} />
+
+      <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+        {/* アバター + アカウント情報 */}
+        <Box display="flex" alignItems="center" gap={2} mb={3}>
+          <Avatar
+            sx={{
+              width: 72,
+              height: 72,
+              fontSize: "2rem",
+              bgcolor: "primary.main",
+            }}
+          >
+            {initial}
+          </Avatar>
+          <Box flex={1}>
+            <NicknameForm nickname={nickname} />
+          </Box>
+        </Box>
+
+        <Divider sx={{ mb: 2 }} />
+
+        <Box display="flex" flexDirection="column" gap={0.5}>
+          <Typography variant="body2" color="text.secondary">
+            メール: {profile?.attributes.email ?? session?.user?.email ?? "—"}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            登録日:{" "}
+            {profile?.attributes.created_at
+              ? new Date(profile.attributes.created_at).toLocaleDateString(
+                  "ja-JP",
+                )
+              : "—"}
+          </Typography>
+        </Box>
+      </Paper>
+
+      {/* 活動サマリー */}
+      {profile && (
+        <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+          <ActivitySummary
+            sangakuCount={profile.attributes.sangaku_count}
+            dedicatedSangakuCount={profile.attributes.dedicated_sangaku_count}
+            savedSangakuCount={profile.attributes.saved_sangaku_count}
+            answerCount={profile.attributes.answer_count}
+          />
+        </Paper>
+      )}
+
+      {/* AI生成利用状況 */}
+      <Paper variant="outlined" sx={{ p: 3, mb: 2 }}>
+        <Typography variant="subtitle1" fontWeight="bold" mb={1}>
+          AI生成利用状況
+        </Typography>
+        {usage ? (
+          <Box display="flex" flexDirection="column" gap={0.5}>
+            <Typography variant="body2">
+              本日の残り生成回数:{" "}
+              <Box
+                component="span"
+                sx={{ color: usage.remaining === 0 ? "error.main" : "inherit" }}
+              >
+                {usage.remaining} / {usage.limit}
+              </Box>
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              リセット時刻:{" "}
+              {new Date(usage.reset_at).toLocaleTimeString("ja-JP", {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </Typography>
+          </Box>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            利用状況を取得できませんでした
+          </Typography>
+        )}
+      </Paper>
+
+      {/* プライバシー設定 */}
+      {profile && (
+        <Paper variant="outlined" sx={{ p: 3 }}>
+          <PrivacySettingsCard
+            showAnswerCount={profile.attributes.show_answer_count}
+          />
+        </Paper>
+      )}
     </Box>
   );
 }

--- a/auth.ts
+++ b/auth.ts
@@ -7,7 +7,7 @@ import Credentials from "next-auth/providers/credentials";
 import { setFlash } from "@/app/lib/actions/flash";
 import { buildHeaders } from "@/app/lib/client_headers";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 const providers: Provider[] = [Google];
 

--- a/env.template
+++ b/env.template
@@ -1,2 +1,1 @@
 API_URL=http://localhost:3000
-NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/env.template
+++ b/env.template
@@ -1,1 +1,2 @@
+API_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:3000

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,20 +14,11 @@ export default auth(async (req) => {
   const isApiAuthRoute = nextUrl.pathname.startsWith(apiAuthPrefix);
   // const isPublicRoute = publicRoutes.includes(nextUrl.pathname);
 
-  let flag = false;
-  publicRoutes.map((route) => {
-    if (typeof route === "string") {
-      if (route === nextUrl.pathname) {
-        flag = true;
-      }
-    } else {
-      if (route.test(nextUrl.pathname)) {
-        flag = true;
-      }
-    }
-  });
-
-  const isPublicRoute = flag;
+  const isPublicRoute = publicRoutes.some((route) =>
+    typeof route === "string"
+      ? route === nextUrl.pathname
+      : route.test(nextUrl.pathname),
+  );
 
   const isAuthRoute = authRoutes.includes(nextUrl.pathname);
 

--- a/routes.ts
+++ b/routes.ts
@@ -2,6 +2,7 @@ export const publicRoutes: (string | RegExp)[] = [
   "/",
   "/shrines",
   /\/shrines\/.*\/sangakus/,
+  /\/profiles\/.+/,
   "/privacy_policy",
   "/terms_of_use",
 ];

--- a/tests/__helpers__/hydration.ts
+++ b/tests/__helpers__/hydration.ts
@@ -16,3 +16,17 @@ export async function waitForInteractive(locator: Locator) {
 export async function waitForNetworkIdle(page: Page) {
   await page.waitForLoadState("networkidle");
 }
+
+/**
+ * Monaco Editor が完全に読み込まれるまで待つ。
+ * .view-lines が visible になった時点で Monaco の初期化とレンダリングが完了している。
+ * @param page - Playwright の Page オブジェクト
+ * @param nth  - ページ内に複数の Monaco Editor がある場合のインデックス（デフォルト: 0）
+ */
+export async function waitForMonacoEditor(page: Page, nth = 0) {
+  await page
+    .locator(".monaco-editor")
+    .nth(nth)
+    .locator(".view-lines")
+    .waitFor({ state: "visible", timeout: 10_000 });
+}

--- a/tests/__helpers__/hydration.ts
+++ b/tests/__helpers__/hydration.ts
@@ -28,5 +28,5 @@ export async function waitForMonacoEditor(page: Page, nth = 0) {
     .locator(".monaco-editor")
     .nth(nth)
     .locator(".view-lines")
-    .waitFor({ state: "visible", timeout: 10_000 });
+    .waitFor({ state: "visible", timeout: 20_000 });
 }

--- a/tests/components/sangaku/UserSangaku.spec.tsx
+++ b/tests/components/sangaku/UserSangaku.spec.tsx
@@ -9,7 +9,7 @@ const sangaku: Sangaku = {
     title: "test_title",
     description: "test_desc",
     source: "puts 'hi'",
-    difficulty: "nomal",
+    difficulty: "normal",
     author_name: "test_author",
     inputs: [
       {

--- a/tests/e2e/profiles/[id]/page.spec.ts
+++ b/tests/e2e/profiles/[id]/page.spec.ts
@@ -1,0 +1,154 @@
+import {
+  test,
+  expect,
+  http,
+  HttpResponse,
+  passthrough,
+} from "next/experimental/testmode/playwright/msw";
+
+const apiUrl = process.env.API_URL;
+
+const profileWithAnswerCount = {
+  data: {
+    id: "1",
+    type: "profile",
+    attributes: {
+      nickname: "test nickname",
+      created_at: "2026-01-01T00:00:00.000+09:00",
+      sangaku_count: 2,
+      dedicated_sangaku_count: 1,
+      answer_count: 5,
+      dedicated_sangakus: [
+        { id: 1, title: "test_sangaku_title", shrine_name: "test_shrine" },
+      ],
+    },
+  },
+};
+
+const profileWithoutAnswerCount = {
+  data: {
+    id: "2",
+    type: "profile",
+    attributes: {
+      nickname: "private nickname",
+      created_at: "2026-02-01T00:00:00.000+09:00",
+      sangaku_count: 3,
+      dedicated_sangaku_count: 0,
+      answer_count: null,
+      dedicated_sangakus: [],
+    },
+  },
+};
+
+test.describe("/profiles/[id]", () => {
+  test.use({
+    mswHandlers: [
+      [
+        http.get(`${apiUrl}/api/v1/profiles/1`, () => {
+          return HttpResponse.json(profileWithAnswerCount, { status: 200 });
+        }),
+        http.get(`${apiUrl}/api/v1/profiles/2`, () => {
+          return HttpResponse.json(profileWithoutAnswerCount, { status: 200 });
+        }),
+        http.get(`${apiUrl}/api/v1/profiles/999`, () => {
+          return new HttpResponse(null, { status: 404 });
+        }),
+        http.all("*", () => passthrough()),
+      ],
+      { scope: "test" },
+    ],
+  });
+
+  test.describe("without signin (public route)", () => {
+    test("should display nickname and registration date", async ({ page }) => {
+      await page.goto("/profiles/1");
+      await page.waitForLoadState();
+
+      await expect(page.getByRole("heading", { name: "プロフィール" })).toBeVisible();
+      // nickname renders as <h6> (Typography variant="h6")
+      await expect(page.getByRole("heading", { name: "test nickname" })).toBeVisible();
+      await expect(page.getByText(/登録日.*2026/)).toBeVisible();
+    });
+
+    test("should display activity summary", async ({ page }) => {
+      await page.goto("/profiles/1");
+      await page.waitForLoadState();
+
+      // subtitle1 renders as <h6>
+      await expect(page.getByRole("heading", { name: "活動サマリー" })).toBeVisible();
+      await expect(page.getByText("作成した算額")).toBeVisible();
+      // "奉納済み算額" appears in both StatCard label (span) and section heading (h6)
+      // target only the caption span inside the activity summary stat card
+      await expect(
+        page.locator("span").filter({ hasText: /^奉納済み算額$/ }),
+      ).toBeVisible();
+    });
+
+    test("should display answer count as number when show_answer_count is true", async ({
+      page,
+    }) => {
+      await page.goto("/profiles/1");
+      await page.waitForLoadState();
+
+      await expect(page.getByText("提出した回答")).toBeVisible();
+      const answerCard = page
+        .getByText("提出した回答")
+        .locator("..")
+        .locator("..");
+      await expect(answerCard.getByText("5")).toBeVisible();
+    });
+
+    test("should display dash when answer_count is null (show_answer_count is false)", async ({
+      page,
+    }) => {
+      await page.goto("/profiles/2");
+      await page.waitForLoadState();
+
+      await expect(page.getByText("提出した回答")).toBeVisible();
+      const answerCard = page
+        .getByText("提出した回答")
+        .locator("..")
+        .locator("..");
+      await expect(answerCard.getByText("—")).toBeVisible();
+    });
+
+    test("should display dedicated sangaku list with title and shrine name", async ({
+      page,
+    }) => {
+      await page.goto("/profiles/1");
+      await page.waitForLoadState();
+
+      // section heading (subtitle1 = h6)
+      await expect(page.getByRole("heading", { name: "奉納済み算額" })).toBeVisible();
+      // ListItem renders as <li> (listitem role)
+      await expect(
+        page.getByRole("listitem").filter({ hasText: "test_sangaku_title" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("listitem").filter({ hasText: "test_shrine" }),
+      ).toBeVisible();
+    });
+
+    test("should display empty message when no dedicated sangakus", async ({
+      page,
+    }) => {
+      await page.goto("/profiles/2");
+      await page.waitForLoadState();
+
+      await expect(
+        page.getByText("奉納済みの算額はありません"),
+      ).toBeVisible();
+    });
+
+    test("should display not found page for non-existent id", async ({
+      page,
+    }) => {
+      await page.goto("/profiles/999");
+      await page.waitForLoadState();
+
+      await expect(
+        page.getByRole("heading", { name: "This page could not be found." }),
+      ).toBeVisible();
+    });
+  });
+});

--- a/tests/e2e/profiles/[id]/page.spec.ts
+++ b/tests/e2e/profiles/[id]/page.spec.ts
@@ -120,13 +120,9 @@ test.describe("/profiles/[id]", () => {
 
       // section heading (subtitle1 = h6)
       await expect(page.getByRole("heading", { name: "奉納済み算額" })).toBeVisible();
-      // ListItem renders as <li> (listitem role)
-      await expect(
-        page.getByRole("listitem").filter({ hasText: "test_sangaku_title" }),
-      ).toBeVisible();
-      await expect(
-        page.getByRole("listitem").filter({ hasText: "test_shrine" }),
-      ).toBeVisible();
+      // sangaku title and shrine name inside Ema component
+      await expect(page.getByText("test_sangaku_title")).toBeVisible();
+      await expect(page.getByText("test_shrine")).toBeVisible();
     });
 
     test("should display empty message when no dedicated sangakus", async ({

--- a/tests/e2e/profiles/[id]/page.spec.ts
+++ b/tests/e2e/profiles/[id]/page.spec.ts
@@ -14,7 +14,7 @@ const profileWithAnswerCount = {
     type: "profile",
     attributes: {
       nickname: "test nickname",
-      created_at: "2026-01-01T00:00:00.000+09:00",
+      created_at: "2026-06-01T00:00:00.000Z",
       sangaku_count: 2,
       dedicated_sangaku_count: 1,
       answer_count: 5,
@@ -31,7 +31,7 @@ const profileWithoutAnswerCount = {
     type: "profile",
     attributes: {
       nickname: "private nickname",
-      created_at: "2026-02-01T00:00:00.000+09:00",
+      created_at: "2026-07-01T00:00:00.000Z",
       sangaku_count: 3,
       dedicated_sangaku_count: 0,
       answer_count: null,

--- a/tests/e2e/sangakus/create/page.spec.ts
+++ b/tests/e2e/sangakus/create/page.spec.ts
@@ -9,7 +9,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/sangakus/create", () => {
   test.describe("before signin", () => {

--- a/tests/e2e/sangakus/create/page.spec.ts
+++ b/tests/e2e/sangakus/create/page.spec.ts
@@ -65,7 +65,7 @@ test.describe("/sangakus/create", () => {
             title: "test_title",
             description: "test_description",
             source: 'input = gets.chomp\nputs "test #{input}',
-            difficulty: "nomal",
+            difficulty: "normal",
             inputs: [
               {
                 id: 15,
@@ -152,7 +152,7 @@ test.describe("/sangakus/create", () => {
             title: "test_title",
             description: "test_description",
             source: generatedSource,
-            difficulty: "nomal",
+            difficulty: "normal",
             inputs: [{ id: 15, content: "5" }],
           },
           relationships: {

--- a/tests/e2e/sangakus/create/page.spec.ts
+++ b/tests/e2e/sangakus/create/page.spec.ts
@@ -1,5 +1,5 @@
 import { setSession } from "../../../__helpers__/signin";
-import { waitForInteractive } from "../../../__helpers__/hydration";
+import { waitForInteractive, waitForMonacoEditor } from "../../../__helpers__/hydration";
 
 import {
   test,
@@ -98,6 +98,7 @@ test.describe("/sangakus/create", () => {
       await page.getByLabel("問題文").fill("test_description");
       await page.getByRole("textbox", { name: "fixedInput-1" }).fill("example");
       const monacoEditor = page.locator(".monaco-editor").nth(0);
+      await waitForMonacoEditor(page);
       await monacoEditor.click();
       await page.keyboard.press("ControlOrMeta+a");
       await page.keyboard.press("Backspace");
@@ -125,6 +126,7 @@ test.describe("/sangakus/create", () => {
       await setSession(page);
       await page.goto("/sangakus/create");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       const generateButton = page.getByRole("button", {
@@ -179,6 +181,7 @@ test.describe("/sangakus/create", () => {
       await setSession(page);
       await page.goto("/sangakus/create");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       await page.getByLabel("タイトル").fill("test_title");
@@ -196,19 +199,9 @@ test.describe("/sangakus/create", () => {
       await expect(generateButton).toBeEnabled({ timeout: 10000 });
 
       // 生成されたコードがMonaco Editorに反映されているか確認
-      const editorContent = await page.evaluate(() => {
-        const models =
-          (
-            window as unknown as {
-              monaco?: {
-                editor?: { getModels?: () => { getValue?: () => string }[] };
-              };
-            }
-          ).monaco?.editor?.getModels?.() || [];
-        return models[0]?.getValue?.() || "";
-      });
-      expect(editorContent).not.toBe("");
-      expect(editorContent).toContain("対応言語: Ruby");
+      // window.monaco は非同期で更新されるため、DOMベースのリトライで確認する
+      const editorLines = page.locator(".monaco-editor").first().locator(".view-lines");
+      await expect(editorLines).toContainText("対応言語: Ruby", { timeout: 10000 });
 
       // 確認画面を通じて保存できる
       await page.getByRole("button", { name: "確認画面へ" }).click();
@@ -254,6 +247,7 @@ test.describe("/sangakus/create", () => {
       await page.getByRole("textbox", { name: "fixedInput-2" }).fill("example");
       // NOTE: monaco-editorの操作
       const monacoEditor = page.locator(".monaco-editor").nth(0);
+      await waitForMonacoEditor(page);
       await monacoEditor.click();
       await page.keyboard.press("ControlOrMeta+a");
       await page.keyboard.press("Backspace");
@@ -308,6 +302,7 @@ test.describe("/sangakus/create", () => {
       await setSession(page);
       await page.goto("/sangakus/create");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       await page.getByLabel("問題文").fill("nを出力してください");
@@ -328,6 +323,7 @@ test.describe("/sangakus/create", () => {
       await setSession(page);
       await page.goto("/sangakus/create");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       await page.getByLabel("問題文").fill("問題文を入力");

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -17,6 +17,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
       await page.waitForLoadState();
       await page.goto("/saved_sangakus/1/answer/create");
       await expect(page).toHaveURL("/signin");
+      await page.waitForLoadState();
       const flash = page.locator('[role="alert"]:not([aria-live]):not([aria-atomic])');
       await expect(flash).toBeVisible({ timeout: 10_000 });
       await expect(flash).toContainText("サインインしてください");

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -7,7 +7,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/saved_sangakus/[id]/answer/create", () => {
   test.describe("before signin", () => {

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -1,4 +1,5 @@
 import { setSession } from "@/tests/__helpers__/signin";
+import { waitForMonacoEditor } from "@/tests/__helpers__/hydration";
 import {
   test,
   expect,
@@ -230,6 +231,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
         const description = page.getByText("test_desc");
         await expect(description).toBeVisible();
         const monacoEditor = page.locator(".monaco-editor").nth(0);
+        await waitForMonacoEditor(page);
         await monacoEditor.click();
         await page.keyboard.press("ControlOrMeta+a");
         await page.keyboard.press("Backspace");
@@ -269,6 +271,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
         const description = page.getByText("test_desc");
         await expect(description).toBeVisible();
         const monacoEditor = page.locator(".monaco-editor").nth(0);
+        await waitForMonacoEditor(page);
         await monacoEditor.click();
         await page.keyboard.press("ControlOrMeta+a");
         await page.keyboard.press("Backspace");

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -36,7 +36,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
                     title: "test_title",
                     description: "test_desc",
                     source: "input = gets.chomp\nputs input",
-                    difficulty: "nomal",
+                    difficulty: "normal",
                     inputs: [
                       {
                         id: 1,

--- a/tests/e2e/saved_sangakus/[id]/answer/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/page.spec.ts
@@ -7,7 +7,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/saved_sangakus/[id]/answer", () => {
   test.describe("before signin", () => {

--- a/tests/e2e/saved_sangakus/[id]/answer/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/page.spec.ts
@@ -36,7 +36,7 @@ test.describe("/saved_sangakus/[id]/answer", () => {
                     title: "test_title",
                     description: "test_desc",
                     source: "input = gets.chomp\nputs input",
-                    difficulty: "nomal",
+                    difficulty: "normal",
                     inputs: [
                       {
                         id: 1,

--- a/tests/e2e/saved_sangakus/page.spec.ts
+++ b/tests/e2e/saved_sangakus/page.spec.ts
@@ -7,7 +7,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/saved_sangakus", () => {
   test.describe("before signin", () => {

--- a/tests/e2e/saved_sangakus/page.spec.ts
+++ b/tests/e2e/saved_sangakus/page.spec.ts
@@ -135,7 +135,7 @@ test.describe("/saved_sangakus", () => {
       await page.goto("/saved_sangakus");
       await expect(page).toHaveURL("/saved_sangakus");
       const sangakuTitle = page.getByRole("heading", { name: "test_title" });
-      await expect(sangakuTitle).toBeVisible();
+      await expect(sangakuTitle).toBeVisible({ timeout: 10_000 });
     });
 
     test("should allow me to show answered sangakus", async ({ page }) => {

--- a/tests/e2e/saved_sangakus/page.spec.ts
+++ b/tests/e2e/saved_sangakus/page.spec.ts
@@ -141,9 +141,10 @@ test.describe("/saved_sangakus", () => {
     test("should allow me to show answered sangakus", async ({ page }) => {
       await setSession(page);
       await page.goto("/saved_sangakus?tab=answered");
+      await page.waitForLoadState();
       await expect(page).toHaveURL("/saved_sangakus?tab=answered");
       const sangakuTitle = page.getByRole("heading", { name: "answered" });
-      await expect(sangakuTitle).toBeVisible();
+      await expect(sangakuTitle).toBeVisible({ timeout: 10_000 });
     });
   });
 });

--- a/tests/e2e/saved_sangakus/page.spec.ts
+++ b/tests/e2e/saved_sangakus/page.spec.ts
@@ -40,7 +40,7 @@ test.describe("/saved_sangakus", () => {
                         title: "test_title",
                         description: "test_desc",
                         source: "puts 'hi'",
-                        difficulty: "nomal",
+                        difficulty: "normal",
                         inputs: [
                           {
                             id: 1,
@@ -85,7 +85,7 @@ test.describe("/saved_sangakus", () => {
                         title: "answered",
                         description: "test_desc",
                         source: "puts 'hi'",
-                        difficulty: "nomal",
+                        difficulty: "normal",
                         inputs: [
                           {
                             id: 1,

--- a/tests/e2e/shrines/dedicate/page.spec.ts
+++ b/tests/e2e/shrines/dedicate/page.spec.ts
@@ -8,7 +8,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/shrines/[id]/dedicate", () => {
   test.use({

--- a/tests/e2e/shrines/sangakus/page.spec.ts
+++ b/tests/e2e/shrines/sangakus/page.spec.ts
@@ -7,7 +7,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/shrines/[id]/sangakus", () => {
   test.use({

--- a/tests/e2e/shrines/sangakus/page.spec.ts
+++ b/tests/e2e/shrines/sangakus/page.spec.ts
@@ -49,7 +49,7 @@ test.describe("/shrines/[id]/sangakus", () => {
                   title: "test_title",
                   description: "test_description",
                   source: "put 'Hello world'",
-                  difficulty: "nomal",
+                  difficulty: "normal",
                   inputs: [],
                 },
                 relationships: {
@@ -81,7 +81,7 @@ test.describe("/shrines/[id]/sangakus", () => {
                     title: "test_title",
                     description: "test_description",
                     source: "put 'Hello world'",
-                    difficulty: "nomal",
+                    difficulty: "normal",
                     inputs: [],
                   },
                   relationships: {

--- a/tests/e2e/user/profile/page.spec.ts
+++ b/tests/e2e/user/profile/page.spec.ts
@@ -7,7 +7,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/user/profile", () => {
   test.describe("before signin", () => {
@@ -33,6 +33,24 @@ test.describe("/user/profile", () => {
     test.use({
       mswHandlers: [
         [
+          http.get(`${apiUrl}/api/v1/user/profile`, () => {
+            return HttpResponse.json({
+              data: {
+                id: "1",
+                type: "my_profile",
+                attributes: {
+                  email: "user_1@example.com",
+                  nickname: "test nickname",
+                  show_answer_count: false,
+                  created_at: "2026-01-01T00:00:00.000+09:00",
+                  sangaku_count: 0,
+                  dedicated_sangaku_count: 0,
+                  saved_sangaku_count: 0,
+                  answer_count: 0,
+                },
+              },
+            });
+          }),
           http.patch(`${apiUrl}/api/v1/user/profile`, () => {
             return HttpResponse.json({
               data: {
@@ -48,23 +66,32 @@ test.describe("/user/profile", () => {
               },
             });
           }),
+          http.get(`${apiUrl}/api/v1/user/sangakus/generate_source_usage`, () => {
+            return HttpResponse.json({
+              used: 0,
+              limit: 5,
+              remaining: 5,
+              reset_at: "2026-01-02T00:00:00.000+09:00",
+            });
+          }),
           http.all("*", () => {
             return passthrough();
           }),
         ],
-        { scope: "test" }, // or 'worker'
+        { scope: "test" },
       ],
     });
 
     test("should allow me to edit profile", async ({ page }) => {
       await setSession(page);
       await page.goto("/user/profile");
+      await page.waitForLoadState();
       await page
         .getByRole("textbox", { name: "ニックネーム" })
         .fill("changed_name");
-      const button = page.getByRole("button", { name: "更新する" });
+      const button = page.getByRole("button", { name: "保存" });
       await button.click();
-      await expect(page).toHaveURL("/");
+      await expect(page).toHaveURL("/user/profile");
       const flash = page.locator('[role="alert"]:not([aria-live]):not([aria-atomic])');
       await expect(flash).toBeVisible({ timeout: 10_000 });
       await expect(flash).toContainText("プロフィールを更新しました");

--- a/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
+++ b/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
@@ -8,7 +8,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 test.describe("/user/sangakus/[id]/edit", () => {
   test.describe("before signin", () => {

--- a/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
+++ b/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
@@ -42,7 +42,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
                     title: "before_edit",
                     description: "test_description",
                     source: 'input = gets.chomp\nputs "test #{input}',
-                    difficulty: "nomal",
+                    difficulty: "normal",
                     inputs: [
                       {
                         id: 1,
@@ -185,7 +185,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
             title: "before_edit",
             description: "test_description",
             source: generatedSource,
-            difficulty: "nomal",
+            difficulty: "normal",
             inputs: [{ id: 1, content: "example" }],
           },
           relationships: { user: { data: { id: "1", type: "user" } } },
@@ -333,7 +333,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
                     title: "before_edit",
                     description: "test_description",
                     source: 'input = gets.chomp\nputs "test #{input}',
-                    difficulty: "nomal",
+                    difficulty: "normal",
                     inputs: [{ id: 1, content: "example" }],
                   },
                   relationships: { user: { data: { id: "1", type: "user" } } },

--- a/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
+++ b/tests/e2e/user/sangakus/[id]/edit/page.spec.ts
@@ -1,5 +1,5 @@
 import { setSession } from "@/tests/__helpers__/signin";
-import { waitForInteractive } from "@/tests/__helpers__/hydration";
+import { waitForInteractive, waitForMonacoEditor } from "@/tests/__helpers__/hydration";
 import {
   test,
   expect,
@@ -123,6 +123,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
       await page.getByLabel("タイトル").fill("test_changed");
       await page.getByLabel("問題文").fill("changed_description");
       const monacoEditor = page.locator(".monaco-editor").nth(0);
+      await waitForMonacoEditor(page);
       await monacoEditor.click();
       await page.keyboard.press("ControlOrMeta+a");
       await page.keyboard.press("Backspace");
@@ -157,6 +158,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
       await setSession(page);
       await page.goto("/user/sangakus/1/edit");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       // 初期値（"test_description"）が入っているのでボタンは有効
@@ -210,6 +212,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
       await setSession(page);
       await page.goto("/user/sangakus/1/edit");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       const generateButton = page.getByRole("button", {
@@ -222,13 +225,9 @@ test.describe("/user/sangakus/[id]/edit", () => {
       await expect(generateButton).toBeEnabled({ timeout: 10000 });
 
       // 生成されたコードがMonaco Editorに反映されているか確認
-      const editorContent = await page.evaluate(() => {
-        const models =
-          (window as unknown as { monaco?: { editor?: { getModels?: () => { getValue?: () => string }[] } } }).monaco?.editor?.getModels?.() || [];
-        return models[0]?.getValue?.() || "";
-      });
-      expect(editorContent).not.toBe("");
-      expect(editorContent).toContain("対応言語: Ruby");
+      // window.monaco は非同期で更新されるため、DOMベースのリトライで確認する
+      const editorLines = page.locator(".monaco-editor").first().locator(".view-lines");
+      await expect(editorLines).toContainText("対応言語: Ruby", { timeout: 10000 });
 
       // 確認画面を通じて保存できる
       await page.getByRole("button", { name: "確認画面へ" }).click();
@@ -281,6 +280,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
       await setSession(page);
       await page.goto("/user/sangakus/1/edit");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       await expect(page.getByLabel("問題文")).toHaveValue("test_description");
@@ -301,6 +301,7 @@ test.describe("/user/sangakus/[id]/edit", () => {
       await setSession(page);
       await page.goto("/user/sangakus/1/edit");
       await page.waitForLoadState();
+      await waitForMonacoEditor(page);
       await waitForInteractive(page.getByLabel("問題文"));
 
       await page.getByRole("button", { name: "問題文からコードを生成" }).click();

--- a/tests/e2e/user/sangakus/page.spec.ts
+++ b/tests/e2e/user/sangakus/page.spec.ts
@@ -19,7 +19,7 @@ const beforeDedicateSangakus = {
         title: "test_title",
         description: "test_desc",
         source: "puts 'hi'",
-        difficulty: "nomal",
+        difficulty: "normal",
         inputs: [
           {
             id: 1,
@@ -51,7 +51,7 @@ const alreadyDedicateSangakus = {
         title: "dedicated",
         description: "test_desc",
         source: "puts 'hi'",
-        difficulty: "nomal",
+        difficulty: "normal",
         inputs: [
           {
             id: 1,
@@ -85,7 +85,7 @@ const deleteResponse = {
       title: "test_title",
       description: "test_desc",
       source: "puts 'hi'",
-      difficulty: "nomal",
+      difficulty: "normal",
       inputs: [
         {
           id: 1,

--- a/tests/e2e/user/sangakus/page.spec.ts
+++ b/tests/e2e/user/sangakus/page.spec.ts
@@ -8,7 +8,7 @@ import {
   passthrough,
 } from "next/experimental/testmode/playwright/msw";
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+const apiUrl = process.env.API_URL;
 
 const beforeDedicateSangakus = {
   data: [


### PR DESCRIPTION
## 概要

ユーザープロフィール画面の実装を行いました。

- **公開プロフィールページ** (`/profiles/[id]`): ニックネーム・登録日・活動サマリー（奉納済み算額数）・奉納済み算額一覧を表示。`Ema` コンポーネントで算額を絵馬形式に表示
- **マイプロフィール画面** (`/user/profile`): ニックネーム変更フォーム・解答数の公開/非公開設定を追加
- **E2E テスト**: `/profiles/[id]` の E2E テストを新規追加。既存テストの Monaco Editor 読み込み待機処理を統一 (`waitForMonacoEditor` ヘルパー導入)

Close #65

## 確認方法

1. バックエンドを起動してください
2. フロントエンドを起動してください (`pnpm dev`)
3. `/profiles/[id]` にアクセスし、ニックネーム・活動サマリー・奉納済み算額一覧が表示されることを確認してください
4. `/user/profile` にアクセスし、ニックネーム変更・解答数公開設定が動作することを確認してください
5. E2E テストを実行してください (`pnpm test:e2e`)

## 影響範囲

- `app/profiles/[id]/page.tsx` — 新規追加
- `app/user/profile/page.tsx` — ニックネームフォーム・プライバシー設定カードを追加
- `app/ui/profile/` — 各 UI コンポーネントを新規追加
- `app/lib/data/profile.ts` / `app/lib/actions/profile.ts` — プロフィール取得・更新の API 連携
- `middleware.ts` — `/profiles/` を認証不要パスに追加
- `tests/__helpers__/hydration.ts` — `waitForMonacoEditor` ヘルパーを追加
- 既存 E2E テスト (Monaco Editor を使うテスト全般) — `waitForMonacoEditor` に統一

## チェックリスト

- [ ] siderをパスした
- [x] インテグレーションテストを追加した
- [x] Lint のチェックをパスした
- [x] ユニットテストをパスした
- [ ] 必要なドキュメントを作成した

## コメント

- Monaco Editor は重い非同期ライブラリのため、`.view-lines` が visible になるまで待機する `waitForMonacoEditor` ヘルパーを導入し、Firefox 等での並列実行タイムアウトを解消しました
- `window.monaco.editor.getModels()` を使った DOM 外評価は Monaco の内部更新が非同期なため信頼性が低く、DOM ベースの `.view-lines` による確認に統一しています