### PR TITLE
feat: レート制限(429)時に warning フラッシュを表示 (#76)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
       - name: Create AuthSecret
         run: echo "AUTH_SECRET=$(openssl rand -base64 32)" >> .env
       - name: Build Next.js
+        env:
+          E2E_MOCK_MAPS: "true"
         run: pnpm run build
       - name: Upload .next
         uses: actions/upload-artifact@v4

--- a/app/lib/data/shrine.ts
+++ b/app/lib/data/shrine.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { setFlash } from "../actions/flash";
+import { handleApiError } from "../handle_api_error";
 import { Shrine } from "../definitions";
 import { buildHeaders } from "@/app/lib/client_headers";
 
@@ -24,6 +25,9 @@ export async function fetchShrines(
     if (res.status == 200) {
       const data = await res.json();
       return data.data as Shrine[];
+    } else if (res.status == 429) {
+      await handleApiError(res);
+      return [] as Shrine[];
     } else {
       await setFlash({ type: "error", message: "神社を読み込めませんでした" });
       return [] as Shrine[];

--- a/app/lib/handle_api_error.ts
+++ b/app/lib/handle_api_error.ts
@@ -1,0 +1,18 @@
+import { setFlash } from "./actions/flash";
+
+/**
+ * data/ ・ actions/ の fetch レスポンスに対する共通エラーハンドラ。
+ * 現状は 429（レート制限）時に warning フラッシュを表示する。
+ *
+ * 注意: setFlash は cookie を書き込むため、Server Action 文脈
+ * （Client から呼ばれる action / data 関数）でのみ呼び出すこと。
+ * Server Component のレンダリング中に呼ぶと cookie 書き込みエラーになる。
+ */
+export async function handleApiError(res: Response): Promise<void> {
+  if (res.status === 429) {
+    await setFlash({
+      type: "warning",
+      message: "リクエストが多すぎます。しばらくしてから再試行してください。",
+    });
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,9 +1,23 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 const nextConfig: NextConfig = {
   /* config options here */
   experimental: {
     testProxy: true,
+  },
+  webpack: (config) => {
+    // E2E テスト時は実 Google Maps をロードせずモックに差し替える
+    if (process.env.E2E_MOCK_MAPS === "true") {
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        "@vis.gl/react-google-maps": path.resolve(
+          __dirname,
+          "tests/__mocks__/react-google-maps.tsx",
+        ),
+      };
+    }
+    return config;
   },
 };
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
       : "rm -rf .next && pnpm run build && pnpm run start -p 4020",
     url: "http://localhost:4020",
     reuseExistingServer: false,
+    // ローカルビルド時に Google Maps をモックへ差し替える（CI は build ジョブ側で設定）
+    env: {
+      E2E_MOCK_MAPS: "true",
+    },
   },
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/tests/__mocks__/react-google-maps.tsx
+++ b/tests/__mocks__/react-google-maps.tsx
@@ -1,0 +1,63 @@
+import type { CSSProperties, ReactNode } from "react";
+
+/**
+ * E2E テスト用の `@vis.gl/react-google-maps` モック。
+ *
+ * 実際の Google Maps JS API をロードせず、地図に依存しない最小限のスタブを提供する。
+ * CI には Google Maps の API キーが無く、実地図は AuthFailure で描画されないため、
+ * `useMap().getBounds()` を固定値で返して loadShrines（fetchShrines）を安定して
+ * 呼び出せるようにする。差し替えは next.config.ts の webpack alias（E2E_MOCK_MAPS=true）で行う。
+ */
+
+export function APIProvider({ children }: { children?: ReactNode }) {
+  return <>{children}</>;
+}
+
+export function Map({
+  children,
+  style,
+}: { children?: ReactNode; style?: CSSProperties } & Record<string, unknown>) {
+  return (
+    <div
+      data-testid="map-mock"
+      style={{
+        ...style,
+        backgroundColor: "#cccccc",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: "#555555",
+        fontWeight: "bold",
+      }}
+    >
+      モックマップ（E2E テスト用・実際の地図は表示されません）
+      {children}
+    </div>
+  );
+}
+
+// loadShrines は map.getBounds().getSouthWest()/getNorthEast() を使うため、固定 bounds を返す
+export function useMap() {
+  return {
+    getBounds: () => ({
+      getSouthWest: () => ({ toJSON: () => ({ lat: 35.68, lng: 139.76 }) }),
+      getNorthEast: () => ({ toJSON: () => ({ lat: 35.69, lng: 139.77 }) }),
+    }),
+  };
+}
+
+export function AdvancedMarker({ children }: { children?: ReactNode } & Record<string, unknown>) {
+  return <>{children}</>;
+}
+
+export function Pin() {
+  return null;
+}
+
+export function InfoWindow({ children }: { children?: ReactNode } & Record<string, unknown>) {
+  return <>{children}</>;
+}
+
+export function useAdvancedMarkerRef() {
+  return [() => {}, null] as const;
+}

--- a/tests/e2e/shrines/page.spec.ts
+++ b/tests/e2e/shrines/page.spec.ts
@@ -1,0 +1,45 @@
+import {
+  test,
+  expect,
+  http,
+  HttpResponse,
+  passthrough,
+} from "next/experimental/testmode/playwright/msw";
+
+const apiUrl = process.env.API_URL;
+
+test.describe("/shrines", () => {
+  test.use({
+    geolocation: { latitude: 35.6809591, longitude: 139.7673068 },
+    permissions: ["geolocation"],
+    mswHandlers: [
+      [
+        // レート制限（429）を再現する
+        http.get(`${apiUrl}/api/v1/shrines`, () => {
+          return new HttpResponse(null, { status: 429 });
+        }),
+        // それ以外（Google Maps JS など）は通す
+        http.all("*", () => passthrough()),
+      ],
+      { scope: "test" },
+    ],
+  });
+
+  test("「このエリアで探す」ボタンで 429 のとき warning フラッシュを表示する", async ({
+    page,
+  }) => {
+    await page.goto("/shrines");
+
+    const button = page.getByRole("button", { name: "このエリアで探す" });
+    await expect(button).toBeVisible();
+    await button.click();
+
+    const flash = page.locator(
+      '[role="alert"]:not([aria-live]):not([aria-atomic])',
+    );
+    await expect(flash).toBeVisible({ timeout: 10_000 });
+    await expect(flash).toContainText(
+      "リクエストが多すぎます。しばらくしてから再試行してください。",
+    );
+  });
+});


### PR DESCRIPTION
## 概要

issue #76 対応。バックエンドの Rack::Attack によるレート制限（429）時に、ユーザーへ warning フラッシュ「リクエストが多すぎます。しばらくしてから再試行してください。」を表示する。

共通ハンドラ `app/lib/handle_api_error.ts` を新設し、`fetchShrines`（神社マップ検索）に 429 分岐を追加した。

Closes #76

> **スコープ補足**: 当初 issue は `data/`・`actions/` 全ファイルへの適用を想定していたが、`setFlash` は cookie 書き込みのため **Server Action 文脈でしか動かず**、Server Component のレンダリング中に呼ばれる `data/` 関数では `Cookies can only be modified in a Server Action or Route Handler` エラーになる。そのため今回は Server Action 文脈で安全に動く `fetchShrines` のみに限定した。

## 確認方法

1. `/shrines`（神社を探す）を開く
2. `/api/v1/shrines` が 429 を返す状況で「このエリアで探す」ボタンを押す
3. 「リクエストが多すぎます。しばらくしてから再試行してください。」の warning フラッシュが表示されることを確認
4. E2E: `pnpm test:e2e -- tests/e2e/shrines/page.spec.ts`

## 影響範囲

- `app/lib/data/shrine.ts` の `fetchShrines`（429 分岐を追加。既存の 200 / error 分岐は不変）
- `app/lib/handle_api_error.ts`（新規・共通ハンドラ）
- 他の `data/` `actions/` は変更なし

## チェックリスト

- [x] Lint のチェックをパスした
- [x] E2E テストを追加した（chromium / firefox / webkit 全て pass）
- [ ] 他の `data/` `actions/` への 429 対応（別 issue 想定）

## コメント

混在関数（`fetchUserSangakus` / `fetchShrine`）や Server Component 経由の `data/` 関数への 429 対応は、cookie 制約のため呼び出し側での対応が必要です。必要であれば別 issue で対応します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)