### PR TITLE
fix(test): user/sangakus の flaky な e2e を修正（遷移中の重複DOM対策）

### DIFF
--- a/tests/e2e/user/sangakus/page.spec.ts
+++ b/tests/e2e/user/sangakus/page.spec.ts
@@ -210,7 +210,10 @@ test.describe("/user/sangakus", () => {
       await page.goto("/user/sangakus");
       const sangakuTitle = page.getByRole("heading", { name: "test_title" });
       await expect(sangakuTitle).toBeVisible();
-      const menuButton = page.getByTestId("MoreVertIcon");
+      // サインイン直後のクライアント遷移で前ページの DOM が一時的に重複し
+      // （#menu-button-1 が hidden で2つ並ぶ）strict mode 違反になるため、
+      // 可視要素のみを first() で対象にする
+      const menuButton = page.locator("#menu-button-1:visible").first();
       await waitForInteractive(menuButton);
       await menuButton.click();
       const editLink = page.getByRole("menuitem", { name: "編集" });
@@ -249,7 +252,11 @@ test.describe("/user/sangakus", () => {
     test("can delete sangaku", async ({ page }) => {
       await setSession(page);
       await page.goto("/user/sangakus");
-      const menuButton = page.getByTestId("MoreVertIcon");
+      // サインイン直後のクライアント遷移で前ページの DOM が一時的に重複し
+      // （#menu-button-1 が hidden で2つ並ぶ）strict mode 違反になるため、
+      // 可視要素のみを first() で対象にする
+      const menuButton = page.locator("#menu-button-1:visible").first();
+      await waitForInteractive(menuButton);
       await menuButton.click();
       const deleteButton = page.getByRole("menuitem", { name: "削除" });
       page.once("dialog", async (dialog) => {


### PR DESCRIPTION
## 概要

`tests/e2e/user/sangakus/page.spec.ts` の e2e テストが flaky（実行ごとに失敗テストが変わる）だったため修正する hotfix です。

### 原因
`setSession`（サインイン → `/` へリダイレクト）直後に `goto("/user/sangakus")` が割り込み、**SPA 遷移中に前ページの DOM が一時的に残る**ことがある。その瞬間 `#menu-button-1`（算額メニューの IconButton）が **hidden で2つ並ぶ**ため、未スコープの `getByTestId("MoreVertIcon")` が Playwright の strict mode 違反（2要素マッチ）で intermittent に失敗していた。

ユーザーには見えない遷移中の一過性 DOM であり、プロダクトの不具合ではなくテスト側のロケータ指定の甘さが本質。

### 修正
クリック対象を**可視要素のみ・先頭1つ**に限定する。

- `page.getByTestId("MoreVertIcon")` → `page.locator("#menu-button-1:visible").first()`
- `can delete sangaku` には操作前の安定待ち `waitForInteractive` も追加

## 確認方法

```bash
cd front
# 対象 spec を5回繰り返して flaky が出ないこと
APP_ENV=test npx playwright test --project=chromium --repeat-each=5 tests/e2e/user/sangakus/page.spec.ts
```

- 修正前: 失敗テストが実行ごとに移動（`can delete sangaku` / `should allow me to show own sangakus` が strict mode 違反）
- 修正後: **20 passed**（5 回 × 4 テスト）

## 影響範囲

- 変更は `tests/e2e/user/sangakus/page.spec.ts` の1ファイルのみ（テストコードのみ）
- プロダクトコード・他テストへの影響なし

## チェックリスト

- [x] Lint のチェックをパスした（`pnpm lint`）
- [x] 対象 e2e テストをパスした（`--repeat-each=5` で 20 passed）
- [ ] 必要なドキュメントを作成した（不要）

## コメント

より根本的には `setSession` 末尾でログイン後リダイレクト完了を待つ（`waitForURL`）と全 `after signin` テストが安定しますが、影響範囲が広いため本 hotfix では見送っています。必要なら別途対応します。
