### PR TITLE
fix: PaizaIO 直叩きのハードニング（guestキーenv化・ポーリングtimeout・mutate修正）

### DIFF
--- a/app/lib/actions/sangaku.ts
+++ b/app/lib/actions/sangaku.ts
@@ -11,6 +11,11 @@ import { buildHeaders } from "@/app/lib/client_headers";
 
 const apiUrl = process.env.API_URL!;
 
+// PaizaIO 実行用の設定。api_key は back の ENV.fetch("PAIZAIO_API_KEY", "guest") と統一する
+const PAIZA_API_KEY = process.env.PAIZAIO_API_KEY ?? "guest";
+const POLL_INTERVAL_MS = 200;
+const MAX_POLL_ATTEMPTS = 30; // back PaizaioApi と同値
+
 export type State = {
   errors?: {
     title?: string[];
@@ -194,17 +199,20 @@ export const deleteSangaku = async (id: string) => {
 };
 
 export const runSource = async (source: string, fixedInputs: string[]) => {
-  if (!fixedInputs.length) {
-    fixedInputs.push("");
-  }
+  const inputs = fixedInputs.length ? fixedInputs : [""];
   const results = await Promise.all(
-    fixedInputs.map(async (input) => {
+    inputs.map(async (input) => {
       try {
         const id = await postSource(source, input, "ruby");
         let isSourceComplete = false;
-        while (isSourceComplete === false) {
-          await sleep(200);
+        let attempts = 0;
+        while (!isSourceComplete) {
+          if (attempts >= MAX_POLL_ATTEMPTS) {
+            throw new Error("PaizaIO polling timeout");
+          }
+          await sleep(POLL_INTERVAL_MS);
           isSourceComplete = await getStatus(id);
+          attempts += 1;
         }
         const result = await getDetails(id);
 
@@ -233,7 +241,7 @@ const sleep = (time: number) =>
 
 const postSource = async (source: string, input: string, language: string) => {
   const params = new URLSearchParams({
-    api_key: "guest",
+    api_key: PAIZA_API_KEY,
     source_code: source,
     input,
     language,
@@ -256,7 +264,7 @@ const postSource = async (source: string, input: string, language: string) => {
 
 const getStatus = async (id: string) => {
   const params = new URLSearchParams({
-    api_key: "guest",
+    api_key: PAIZA_API_KEY,
     id,
   });
   const reqUri = `https://api.paiza.io:443/runners/get_status.json?${params}`;
@@ -334,7 +342,7 @@ export const generateSource = async (
 
 const getDetails = async (id: string) => {
   const params = new URLSearchParams({
-    api_key: "guest",
+    api_key: PAIZA_API_KEY,
     id,
   });
   const reqUri = `https://api.paiza.io:443/runners/get_details.json?${params}`;

--- a/env.template
+++ b/env.template
@@ -1,1 +1,4 @@
 API_URL=http://localhost:3000
+
+# PaizaIO のコード実行 API キー（サーバー専用。未設定時は "guest" にフォールバック）
+PAIZAIO_API_KEY=


### PR DESCRIPTION
## 概要

フロントエンドコードレビュー（`front/doc/code_review_2026-06-13.md`）の Blocker **B-2**（#73）のうち、**front 単独で対応可能なハードニング3点**を先行対応する PR です。

`app/lib/actions/sangaku.ts` が PaizaIO（`api.paiza.io`）を Server Action から直接呼んでいる構造はそのままに、以下を是正します。

- **guest キーのハードコード撤廃**: `api_key: "guest"` を `process.env.PAIZAIO_API_KEY ?? "guest"` に統一（back の `ENV.fetch("PAIZAIO_API_KEY", "guest")` と揃える）
- **ポーリングのタイムアウト**: タイムアウトなしの `while` に最大試行回数 `MAX_POLL_ATTEMPTS = 30`（≒6秒）を付与し無限ループを防止（back `PaizaioApi` と同値）。超過時は既存 `catch` が拾い「コードを実行できませんでした」を返す（UI 挙動は不変）
- **破壊的 mutate の廃止**: `fixedInputs.push("")` をやめ `const inputs = fixedInputs.length ? fixedInputs : [""]` に変更

### スコープ外（別 issue へ分割: #78）
- ユーザー単位のレート制限（front は Vercel デプロイのためインメモリ/lru-cache では確実に効かず、back 集約が本命）
- 「保存済み算額に限定」（実行対象はユーザー自身の未保存ドラフトコードのため適用不可と整理）

## 確認方法

```bash
cd front
pnpm lint     # ESLint
pnpm build    # 本番ビルド（型チェック含む）
```

- `.next` クリーンビルドが成功すること、`pnpm lint` がパスすること
- `runSource` のシグネチャ・戻り値（`Promise<string[]>`）は不変のため、呼び出し元（`SourceExecution.tsx` / `SourceResult.tsx`）の改修は不要
- 本番 Vercel では `PAIZAIO_API_KEY` を設定可能（未設定時は従来どおり `"guest"` フォールバック）

## 影響範囲

- 変更ファイル: `app/lib/actions/sangaku.ts`、`env.template` の2ファイルのみ
- `runSource` の公開 I/F 不変。既存の component / e2e テスト、`tests/__mocks__/actions/sangaku.ts` への影響なし

## チェックリスト

- [x] Lint のチェックをパスした（`pnpm lint`）
- [x] 本番ビルドをパスした（`pnpm build`）
- [ ] ユニットテストを追加した（既存挙動の維持のみ・I/F 不変のため新規テストなし）

## コメント

B-2 の本丸である「コード実行のレート制限」は #78 として分割起票済みです。本 PR では front 単独で安全側に倒せる範囲のみを対象にしています。関連レビュー: `front/doc/code_review_2026-06-13.md` B-2。
