### PR TITLE
[FE] admin ユーザー一覧に登録日時ソートUIを追加（#85）

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -9,15 +9,17 @@ import {
 } from "@mui/material";
 import { fetchAdminUsers } from "@/app/lib/data/admin";
 import AdminUserRow from "@/app/ui/admin/AdminUserRow";
+import AdminUserSortHeader from "@/app/ui/admin/AdminUserSortHeader";
 import Pagination from "@/app/ui/Pagination";
 
 interface Props {
-  searchParams: Promise<{ page?: string; query?: string }>;
+  searchParams: Promise<{ page?: string; query?: string; sort?: string }>;
 }
 
 export default async function AdminUsersPage({ searchParams }: Props) {
-  const { page, query } = await searchParams;
-  const result = await fetchAdminUsers(Number(page) || 1, query);
+  const { page, query, sort } = await searchParams;
+  const sortParam = sort === "asc" || sort === "desc" ? sort : undefined;
+  const result = await fetchAdminUsers(Number(page) || 1, query, sortParam);
 
   if (!result) {
     return (
@@ -45,6 +47,7 @@ export default async function AdminUsersPage({ searchParams }: Props) {
             <TableCell>ロール</TableCell>
             <TableCell>算額数</TableCell>
             <TableCell>解答数</TableCell>
+            <AdminUserSortHeader currentSort={sortParam} />
             <TableCell>操作</TableCell>
           </TableRow>
         </TableHead>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -11,6 +11,7 @@ import { fetchAdminUsers } from "@/app/lib/data/admin";
 import AdminUserRow from "@/app/ui/admin/AdminUserRow";
 import AdminUserSortHeader from "@/app/ui/admin/AdminUserSortHeader";
 import Pagination from "@/app/ui/Pagination";
+import Search from "@/app/ui/Search";
 
 interface Props {
   searchParams: Promise<{ page?: string; query?: string; sort?: string }>;
@@ -39,6 +40,7 @@ export default async function AdminUsersPage({ searchParams }: Props) {
       <Typography variant="h4" sx={{ mb: 3 }}>
         ユーザー管理
       </Typography>
+      <Search placeholder="ユーザーを検索" />
       <Table>
         <TableHead>
           <TableRow>
@@ -47,7 +49,7 @@ export default async function AdminUsersPage({ searchParams }: Props) {
             <TableCell>ロール</TableCell>
             <TableCell>算額数</TableCell>
             <TableCell>解答数</TableCell>
-            <AdminUserSortHeader currentSort={sortParam} />
+            <AdminUserSortHeader currentSort={sortParam} query={query} />
             <TableCell>操作</TableCell>
           </TableRow>
         </TableHead>

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -44,7 +44,7 @@ export default async function AdminUsersPage({ searchParams }: Props) {
       <Table>
         <TableHead>
           <TableRow>
-            <TableCell>名前</TableCell>
+            <TableCell>ニックネーム</TableCell>
             <TableCell>メール</TableCell>
             <TableCell>ロール</TableCell>
             <TableCell>算額数</TableCell>

--- a/app/lib/data/admin.ts
+++ b/app/lib/data/admin.ts
@@ -37,6 +37,7 @@ export async function fetchAdminStats(): Promise<AdminStats | undefined | null> 
 export async function fetchAdminUsers(
   page?: number,
   query?: string,
+  sort?: "asc" | "desc",
 ): Promise<{ users: AdminUser[]; totalPages: number } | undefined | null> {
   const session = await requireAdmin();
   if (!session) return undefined;
@@ -44,6 +45,7 @@ export async function fetchAdminUsers(
     const params = new URLSearchParams();
     if (page !== undefined) params.set("page", String(page));
     if (query) params.set("query", query);
+    if (sort) params.set("sort", sort);
     const res = await fetch(`${apiUrl}/api/v1/admin/users?${params}`, {
       headers: buildHeaders(session.accessToken),
     });

--- a/app/ui/admin/AdminUserRow.tsx
+++ b/app/ui/admin/AdminUserRow.tsx
@@ -6,6 +6,10 @@ interface Props {
   user: AdminUser;
 }
 
+function formatDate(isoString: string): string {
+  return isoString.slice(0, 10).replace(/-/g, "/");
+}
+
 export default function AdminUserRow({ user }: Props) {
   const { id, attributes } = user;
 
@@ -16,6 +20,7 @@ export default function AdminUserRow({ user }: Props) {
       <TableCell>{attributes.role}</TableCell>
       <TableCell>{attributes.sangaku_count}</TableCell>
       <TableCell>{attributes.answer_count}</TableCell>
+      <TableCell>{formatDate(attributes.created_at)}</TableCell>
       <TableCell>
         <Button
           component={Link}

--- a/app/ui/admin/AdminUserRow.tsx
+++ b/app/ui/admin/AdminUserRow.tsx
@@ -15,7 +15,7 @@ export default function AdminUserRow({ user }: Props) {
 
   return (
     <TableRow>
-      <TableCell>{attributes.name}</TableCell>
+      <TableCell>{attributes.nickname}</TableCell>
       <TableCell>{attributes.email}</TableCell>
       <TableCell>{attributes.role}</TableCell>
       <TableCell>{attributes.sangaku_count}</TableCell>

--- a/app/ui/admin/AdminUserSortHeader.tsx
+++ b/app/ui/admin/AdminUserSortHeader.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { TableCell, TableSortLabel } from "@mui/material";
+import Link from "next/link";
+
+interface Props {
+  currentSort: "asc" | "desc" | undefined;
+}
+
+function toAriaSort(sort: "asc" | "desc"): "ascending" | "descending" {
+  return sort === "asc" ? "ascending" : "descending";
+}
+
+export default function AdminUserSortHeader({ currentSort }: Props) {
+  const nextSort = currentSort === "asc" ? "desc" : "asc";
+
+  return (
+    <TableCell
+      component="th"
+      scope="col"
+      aria-sort={currentSort ? toAriaSort(currentSort) : undefined}
+    >
+      <TableSortLabel
+        active={currentSort !== undefined}
+        direction={currentSort ?? "asc"}
+        component={Link}
+        href={`?sort=${nextSort}`}
+        data-testid="sort-link"
+        role="button"
+      >
+        登録日時
+      </TableSortLabel>
+    </TableCell>
+  );
+}

--- a/app/ui/admin/AdminUserSortHeader.tsx
+++ b/app/ui/admin/AdminUserSortHeader.tsx
@@ -5,28 +5,32 @@ import Link from "next/link";
 
 interface Props {
   currentSort: "asc" | "desc" | undefined;
+  query?: string;
 }
 
-function toAriaSort(sort: "asc" | "desc"): "ascending" | "descending" {
+function toAriaSort(sort: "asc" | "desc" | undefined): "ascending" | "descending" {
   return sort === "asc" ? "ascending" : "descending";
 }
 
-export default function AdminUserSortHeader({ currentSort }: Props) {
+export default function AdminUserSortHeader({ currentSort, query }: Props) {
   const nextSort = currentSort === "asc" ? "desc" : "asc";
+  const params = new URLSearchParams();
+  if (query) params.set("query", query);
+  params.set("sort", nextSort);
+  const href = `?${params.toString()}`;
 
   return (
     <TableCell
       component="th"
       scope="col"
-      aria-sort={currentSort ? toAriaSort(currentSort) : undefined}
+      aria-sort={toAriaSort(currentSort)}
     >
       <TableSortLabel
-        active={currentSort !== undefined}
-        direction={currentSort ?? "asc"}
+        active={true}
+        direction={currentSort ?? "desc"}
         component={Link}
-        href={`?sort=${nextSort}`}
+        href={href}
         data-testid="sort-link"
-        role="button"
       >
         登録日時
       </TableSortLabel>

--- a/tests/components/admin/AdminUserRow.spec.tsx
+++ b/tests/components/admin/AdminUserRow.spec.tsx
@@ -18,67 +18,72 @@ const user = {
 test.describe("AdminUserRow", () => {
   test("should allow me to see user name", async ({ mount }) => {
     const component = await mount(
-      <table>
-        <tbody>
-          <AdminUserRow user={user} />
-        </tbody>
-      </table>,
+      <table><tbody><AdminUserRow user={user} /></tbody></table>,
     );
     await expect(component.getByText("Test User")).toBeVisible();
   });
 
   test("should allow me to see user email", async ({ mount }) => {
     const component = await mount(
-      <table>
-        <tbody>
-          <AdminUserRow user={user} />
-        </tbody>
-      </table>,
+      <table><tbody><AdminUserRow user={user} /></tbody></table>,
     );
     await expect(component.getByText("test@example.com")).toBeVisible();
   });
 
   test("should allow me to see current role as text", async ({ mount }) => {
     const component = await mount(
-      <table>
-        <tbody>
-          <AdminUserRow user={user} />
-        </tbody>
-      </table>,
+      <table><tbody><AdminUserRow user={user} /></tbody></table>,
     );
     await expect(component.getByText("general")).toBeVisible();
   });
 
   test("should allow me to see edit link", async ({ mount }) => {
     const component = await mount(
-      <table>
-        <tbody>
-          <AdminUserRow user={user} />
-        </tbody>
-      </table>,
+      <table><tbody><AdminUserRow user={user} /></tbody></table>,
     );
     await expect(component.getByRole("link", { name: "編集" })).toBeVisible();
   });
 
   test("should allow me to see sangaku count", async ({ mount }) => {
     const component = await mount(
-      <table>
-        <tbody>
-          <AdminUserRow user={user} />
-        </tbody>
-      </table>,
+      <table><tbody><AdminUserRow user={user} /></tbody></table>,
     );
     await expect(component.getByRole("cell", { name: "3" })).toBeVisible();
   });
 
   test("should allow me to see answer count", async ({ mount }) => {
     const component = await mount(
-      <table>
-        <tbody>
-          <AdminUserRow user={user} />
-        </tbody>
-      </table>,
+      <table><tbody><AdminUserRow user={user} /></tbody></table>,
     );
     await expect(component.getByRole("cell", { name: "7" })).toBeVisible();
+  });
+
+  // RED: AdminUserRow に created_at カラムが存在しない（TableCell で YYYY/MM/DD 形式の日付を表示する実装が未着手）
+  test("should allow me to see created_at formatted as YYYY/MM/DD when ISO string is provided", async ({ mount }) => {
+    // Arrange: 上部 user 定数の created_at = "2026-01-01T00:00:00.000+09:00" を使用
+    // Act
+    const component = await mount(
+      <table><tbody><AdminUserRow user={user} /></tbody></table>,
+    );
+    // Assert
+    await expect(component.getByRole("cell", { name: "2026/01/01" })).toBeVisible();
+  });
+
+  // RED: AdminUserRow に created_at カラムが存在しない（TableCell で YYYY/MM/DD 形式の日付を表示する実装が未着手）
+  test("should allow me to see created_at formatted as YYYY/MM/DD when another ISO string is provided", async ({ mount }) => {
+    // Arrange
+    const userWithDifferentDate = {
+      ...user,
+      attributes: {
+        ...user.attributes,
+        created_at: "2025-12-31T23:59:59.000+09:00",
+      },
+    };
+    // Act
+    const component = await mount(
+      <table><tbody><AdminUserRow user={userWithDifferentDate} /></tbody></table>,
+    );
+    // Assert
+    await expect(component.getByRole("cell", { name: "2025/12/31" })).toBeVisible();
   });
 });

--- a/tests/components/admin/AdminUserRow.spec.tsx
+++ b/tests/components/admin/AdminUserRow.spec.tsx
@@ -16,11 +16,11 @@ const user = {
 };
 
 test.describe("AdminUserRow", () => {
-  test("should allow me to see user name", async ({ mount }) => {
+  test("should allow me to see user nickname", async ({ mount }) => {
     const component = await mount(
       <table><tbody><AdminUserRow user={user} /></tbody></table>,
     );
-    await expect(component.getByText("Test User")).toBeVisible();
+    await expect(component.getByText("testuser")).toBeVisible();
   });
 
   test("should allow me to see user email", async ({ mount }) => {

--- a/tests/components/admin/AdminUserSortHeader.spec.tsx
+++ b/tests/components/admin/AdminUserSortHeader.spec.tsx
@@ -1,0 +1,159 @@
+import { test, expect } from "@/tests/fixtures.ct";
+import AdminUserSortHeader from "@/app/ui/admin/AdminUserSortHeader";
+
+// RED: AdminUserSortHeader コンポーネントが未実装（app/ui/admin/AdminUserSortHeader.tsx が存在しない）
+
+test.describe("AdminUserSortHeader", () => {
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to see label text 登録日時 when rendered", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort={undefined} />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByRole("columnheader", { name: /登録日時/ })).toBeVisible();
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to see columnheader when currentSort is undefined", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort={undefined} />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByRole("columnheader")).toBeVisible();
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to see sort button when currentSort is undefined", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort={undefined} />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByRole("button")).toBeVisible();
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to see columnheader without aria-sort when currentSort is undefined", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort={undefined} />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByRole("columnheader")).not.toHaveAttribute("aria-sort");
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to see ascending sort indicator when currentSort is asc", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort="asc" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByRole("columnheader")).toHaveAttribute("aria-sort", "ascending");
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to see descending sort indicator when currentSort is desc", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort="desc" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByRole("columnheader")).toHaveAttribute("aria-sort", "descending");
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to navigate to ?sort=asc when currentSort is undefined", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort={undefined} />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", /sort=asc/);
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to navigate to ?sort=desc when currentSort is asc", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort="asc" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", /sort=desc/);
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装
+  test("should allow me to navigate to ?sort=asc when currentSort is desc", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort="desc" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", /sort=asc/);
+  });
+});

--- a/tests/components/admin/AdminUserSortHeader.spec.tsx
+++ b/tests/components/admin/AdminUserSortHeader.spec.tsx
@@ -39,7 +39,7 @@ test.describe("AdminUserSortHeader", () => {
   });
 
   // RED: AdminUserSortHeader コンポーネントが未実装
-  test("should allow me to see sort button when currentSort is undefined", async ({ mount }) => {
+  test("should allow me to see sort link when currentSort is undefined", async ({ mount }) => {
     // Arrange
     // Act
     const component = await mount(
@@ -52,7 +52,7 @@ test.describe("AdminUserSortHeader", () => {
       </table>,
     );
     // Assert
-    await expect(component.getByRole("button")).toBeVisible();
+    await expect(component.getByRole("link", { name: /登録日時/ })).toBeVisible();
   });
 
   // RED: AdminUserSortHeader コンポーネントが未実装（currentSort=undefined 時は降順をデフォルト表示する仕様）

--- a/tests/components/admin/AdminUserSortHeader.spec.tsx
+++ b/tests/components/admin/AdminUserSortHeader.spec.tsx
@@ -55,8 +55,8 @@ test.describe("AdminUserSortHeader", () => {
     await expect(component.getByRole("button")).toBeVisible();
   });
 
-  // RED: AdminUserSortHeader コンポーネントが未実装
-  test("should allow me to see columnheader without aria-sort when currentSort is undefined", async ({ mount }) => {
+  // RED: AdminUserSortHeader コンポーネントが未実装（currentSort=undefined 時は降順をデフォルト表示する仕様）
+  test("should allow me to see descending sort indicator when currentSort is undefined", async ({ mount }) => {
     // Arrange
     // Act
     const component = await mount(
@@ -69,7 +69,7 @@ test.describe("AdminUserSortHeader", () => {
       </table>,
     );
     // Assert
-    await expect(component.getByRole("columnheader")).not.toHaveAttribute("aria-sort");
+    await expect(component.getByRole("columnheader")).toHaveAttribute("aria-sort", "descending");
   });
 
   // RED: AdminUserSortHeader コンポーネントが未実装
@@ -106,9 +106,9 @@ test.describe("AdminUserSortHeader", () => {
     await expect(component.getByRole("columnheader")).toHaveAttribute("aria-sort", "descending");
   });
 
-  // RED: AdminUserSortHeader コンポーネントが未実装
+  // RED: AdminUserSortHeader コンポーネントが未実装（query 未渡し時は sort パラメータのみ付与）
   test("should allow me to navigate to ?sort=asc when currentSort is undefined", async ({ mount }) => {
-    // Arrange
+    // Arrange: query prop を渡さない（undefined）
     // Act
     const component = await mount(
       <table>
@@ -120,12 +120,12 @@ test.describe("AdminUserSortHeader", () => {
       </table>,
     );
     // Assert
-    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", /sort=asc/);
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", "?sort=asc");
   });
 
-  // RED: AdminUserSortHeader コンポーネントが未実装
+  // RED: AdminUserSortHeader コンポーネントが未実装（query 未渡し時は sort パラメータのみ付与）
   test("should allow me to navigate to ?sort=desc when currentSort is asc", async ({ mount }) => {
-    // Arrange
+    // Arrange: query prop を渡さない（undefined）
     // Act
     const component = await mount(
       <table>
@@ -137,12 +137,12 @@ test.describe("AdminUserSortHeader", () => {
       </table>,
     );
     // Assert
-    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", /sort=desc/);
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", "?sort=desc");
   });
 
-  // RED: AdminUserSortHeader コンポーネントが未実装
+  // RED: AdminUserSortHeader コンポーネントが未実装（query 未渡し時は sort パラメータのみ付与）
   test("should allow me to navigate to ?sort=asc when currentSort is desc", async ({ mount }) => {
-    // Arrange
+    // Arrange: query prop を渡さない（undefined）
     // Act
     const component = await mount(
       <table>
@@ -154,6 +154,74 @@ test.describe("AdminUserSortHeader", () => {
       </table>,
     );
     // Assert
-    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", /sort=asc/);
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", "?sort=asc");
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装（query を持つ場合は sort と query 両方を保持）
+  test("should allow me to navigate to ?sort=asc and preserve query param when currentSort is undefined", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort={undefined} query="foo" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", "?query=foo&sort=asc");
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装（query を持つ場合は sort と query 両方を保持）
+  test("should allow me to navigate to ?sort=desc and preserve query param when currentSort is asc", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort="asc" query="foo" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", "?query=foo&sort=desc");
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装（query を持つ場合は sort と query 両方を保持）
+  test("should allow me to navigate to ?sort=asc and preserve query param when currentSort is desc", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort="desc" query="foo" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", "?query=foo&sort=asc");
+  });
+
+  // RED: AdminUserSortHeader コンポーネントが未実装（query が空文字の場合は sort パラメータのみ付与）
+  test("should allow me to navigate to ?sort=asc without query param when query is empty and currentSort is undefined", async ({ mount }) => {
+    // Arrange
+    // Act
+    const component = await mount(
+      <table>
+        <thead>
+          <tr>
+            <AdminUserSortHeader currentSort={undefined} query="" />
+          </tr>
+        </thead>
+      </table>,
+    );
+    // Assert
+    await expect(component.getByTestId("sort-link")).toHaveAttribute("href", "?sort=asc");
   });
 });

--- a/tests/e2e/admin/users/page.spec.ts
+++ b/tests/e2e/admin/users/page.spec.ts
@@ -123,7 +123,7 @@ test.describe("/admin/users", () => {
     test("should allow me to see URL changed to ?sort=asc when clicking the created_at sort header with no current sort", async ({ page }) => {
       // Arrange: beforeEach で /admin/users に遷移済み（sort パラメータなし）
       // Act
-      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("button").click();
+      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("link").click();
       // Assert
       await expect(page).toHaveURL(/[?&]sort=asc/);
     });
@@ -133,7 +133,7 @@ test.describe("/admin/users", () => {
       // Arrange
       await page.goto("/admin/users?sort=asc");
       // Act
-      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("button").click();
+      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("link").click();
       // Assert
       await expect(page).toHaveURL(/[?&]sort=desc/);
     });
@@ -171,7 +171,7 @@ test.describe("/admin/users", () => {
       // Arrange
       await page.goto("/admin/users?query=Admin");
       // Act
-      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("button").click();
+      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("link").click();
       // Assert: query と sort の両パラメータが URL に存在すること
       await expect(page).toHaveURL(/[?&]query=Admin/);
       await expect(page).toHaveURL(/[?&]sort=asc/);

--- a/tests/e2e/admin/users/page.spec.ts
+++ b/tests/e2e/admin/users/page.spec.ts
@@ -40,34 +40,39 @@ const usersResponse = {
   ],
 };
 
+// 成功レスポンスハンドラを生成するファクトリ（sort パラメータのキャプチャに対応）
+function makeUsersHandler(onRequest?: (sort: string | null) => void) {
+  return http.get(`${apiUrl}/api/v1/admin/users`, ({ request }) => {
+    if (onRequest) {
+      const url = new URL(request.url);
+      onRequest(url.searchParams.get("sort"));
+    }
+    return new HttpResponse(JSON.stringify(usersResponse), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "current-page": "1",
+        "page-items": "20",
+        "total-pages": "1",
+        "total-count": "2",
+      },
+    });
+  });
+}
+
 test.describe("/admin/users", () => {
   test.use({
     mswHandlers: [
       [
-        http.get(`${apiUrl}/api/v1/admin/users`, () => {
-          return new HttpResponse(JSON.stringify(usersResponse), {
-            status: 200,
-            headers: {
-              "Content-Type": "application/json",
-              "current-page": "1",
-              "page-items": "20",
-              "total-pages": "1",
-              "total-count": "2",
-            },
-          });
-        }),
-        http.all("*", () => {
-          return passthrough();
-        }),
+        makeUsersHandler(),
+        http.all("*", () => passthrough()),
       ],
       { scope: "test" },
     ],
   });
 
   test.describe("unauthenticated user", () => {
-    test("should not allow me to access user list without authentication", async ({
-      page,
-    }) => {
+    test("should not allow me to access user list without authentication", async ({ page }) => {
       await page.goto("/admin/users");
       await expect(page).toHaveURL("/signin");
       const flash = page.getByTestId("flash-message");
@@ -78,9 +83,7 @@ test.describe("/admin/users", () => {
   });
 
   test.describe("general user", () => {
-    test("should not allow me to access user list as a general user", async ({
-      page,
-    }) => {
+    test("should not allow me to access user list as a general user", async ({ page }) => {
       await setSession(page);
       await page.goto("/admin/users");
       await expect(page).toHaveURL("/");
@@ -108,6 +111,31 @@ test.describe("/admin/users", () => {
     test("should allow me to see the edit link for each user", async ({ page }) => {
       const editLinks = page.getByRole("link", { name: "編集" });
       await expect(editLinks.first()).toBeVisible();
+    });
+
+    // RED: AdminUserRow に created_at カラムが存在しない（page.tsx のテーブルに登録日時列・AdminUserSortHeader が未実装）
+    test("should allow me to see created_at formatted as YYYY/MM/DD in the user list", async ({ page }) => {
+      await expect(page.getByText("2026/01/01")).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByText("2026/01/02")).toBeVisible();
+    });
+
+    // RED: AdminUserRow に created_at カラムが存在しない（AdminUserSortHeader が未実装）
+    test("should allow me to see URL changed to ?sort=asc when clicking the created_at sort header with no current sort", async ({ page }) => {
+      // Arrange: beforeEach で /admin/users に遷移済み（sort パラメータなし）
+      // Act
+      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("button").click();
+      // Assert
+      await expect(page).toHaveURL(/[?&]sort=asc/);
+    });
+
+    // RED: AdminUserRow に created_at カラムが存在しない（AdminUserSortHeader が未実装）
+    test("should allow me to toggle sort to desc when clicking the created_at sort header with sort=asc", async ({ page }) => {
+      // Arrange
+      await page.goto("/admin/users?sort=asc");
+      // Act
+      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("button").click();
+      // Assert
+      await expect(page).toHaveURL(/[?&]sort=desc/);
     });
   });
 });

--- a/tests/e2e/admin/users/page.spec.ts
+++ b/tests/e2e/admin/users/page.spec.ts
@@ -137,6 +137,45 @@ test.describe("/admin/users", () => {
       // Assert
       await expect(page).toHaveURL(/[?&]sort=desc/);
     });
+
+    // RED: AdminUserSearchForm が未実装（検索フォームが存在しない）
+    test("should allow me to see search form on the users page", async ({ page }) => {
+      // Arrange: beforeEach で /admin/users に遷移済み
+      // Act: （レンダリングのみ）
+      // Assert
+      await expect(page.getByPlaceholder("ユーザーを検索")).toBeVisible({ timeout: 10_000 });
+    });
+
+    // RED: AdminUserSearchForm が未実装（URL への query パラメータ反映が未実装）
+    test("should allow me to see query param in URL when typing in search form", async ({ page }) => {
+      // Arrange: beforeEach で /admin/users に遷移済み
+      // Act
+      await page.getByPlaceholder("ユーザーを検索").fill("Admin");
+      // Assert
+      await expect(page).toHaveURL(/[?&]query=Admin/, { timeout: 5_000 });
+    });
+
+    // RED: AdminUserSearchForm が未実装（sort パラメータを保持したまま query を反映する機能が未実装）
+    test("should allow me to preserve sort param when typing in search form after sorting", async ({ page }) => {
+      // Arrange
+      await page.goto("/admin/users?sort=asc");
+      // Act
+      await page.getByPlaceholder("ユーザーを検索").fill("Admin");
+      // Assert: sort と query の両パラメータが URL に存在すること
+      await expect(page).toHaveURL(/[?&]sort=asc/, { timeout: 5_000 });
+      await expect(page).toHaveURL(/[?&]query=Admin/);
+    });
+
+    // RED: AdminUserSearchForm が未実装（query パラメータを保持したままソートヘッダーをクリックする機能が未実装）
+    test("should allow me to preserve query param when clicking sort header after searching", async ({ page }) => {
+      // Arrange
+      await page.goto("/admin/users?query=Admin");
+      // Act
+      await page.getByRole("columnheader", { name: /登録日時/ }).getByRole("button").click();
+      // Assert: query と sort の両パラメータが URL に存在すること
+      await expect(page).toHaveURL(/[?&]query=Admin/);
+      await expect(page).toHaveURL(/[?&]sort=asc/);
+    });
   });
 });
 

--- a/tests/e2e/admin/users/page.spec.ts
+++ b/tests/e2e/admin/users/page.spec.ts
@@ -17,7 +17,7 @@ const usersResponse = {
       attributes: {
         name: "Admin User",
         email: "admin@example.com",
-        nickname: "admin",
+        nickname: "admin_nick",
         role: "admin",
         created_at: "2026-01-01T00:00:00.000+09:00",
         sangaku_count: 2,
@@ -30,7 +30,7 @@ const usersResponse = {
       attributes: {
         name: "General User",
         email: "general@example.com",
-        nickname: "general",
+        nickname: "general_nick",
         role: "general",
         created_at: "2026-01-02T00:00:00.000+09:00",
         sangaku_count: 3,
@@ -103,9 +103,9 @@ test.describe("/admin/users", () => {
       ).toBeVisible({ timeout: 10_000 });
     });
 
-    test("should allow me to see user names from API", async ({ page }) => {
-      await expect(page.getByText("Admin User")).toBeVisible();
-      await expect(page.getByText("General User")).toBeVisible();
+    test("should allow me to see user nicknames from API", async ({ page }) => {
+      await expect(page.getByText("admin_nick")).toBeVisible();
+      await expect(page.getByText("general_nick")).toBeVisible();
     });
 
     test("should allow me to see the edit link for each user", async ({ page }) => {


### PR DESCRIPTION
## 概要

admin ユーザー一覧に以下の機能を追加しました。

- **ソートUI**: 登録日時カラムのクリックで昇順/降順を切り替えられるソートヘッダー（デフォルト:降順表示）
- **検索フォーム**: ユーザー名・メールアドレスで絞り込める検索フォーム
- **パラメータ保持**: ソートと検索を同時に使用した場合も双方のURLパラメータを保持
- **登録日時カラム**: AdminUserRow に `created_at` を `YYYY/MM/DD` 形式で表示

関連 issue: #85

## 確認方法

1. `/admin/users` にアクセスする
2. テーブルの「登録日時」カラムヘッダーをクリックする
3. URL が `?sort=asc` に変わり、昇順でユーザーが表示されることを確認する
4. 再度クリックすると `?sort=desc`（降順）に切り替わることを確認する
5. ページ上部の検索フォームに文字を入力し、URL に `?query=...` が付くことを確認する
6. ソート状態で検索しても `sort` パラメータが保持されることを確認する
7. 検索状態でソートをクリックしても `query` パラメータが保持されることを確認する

## 影響範囲

- `app/admin/users/page.tsx` — `searchParams.sort` / `query` を受け取り、Search・AdminUserSortHeader に渡す
- `app/lib/data/admin.ts` — `fetchAdminUsers` に `sort` パラメータを追加
- `app/ui/admin/AdminUserRow.tsx` — 登録日時カラム追加
- `app/ui/admin/AdminUserSortHeader.tsx` — ソートトグルUI（新規作成）
- `app/ui/Search.tsx` — 既存コンポーネントを流用（変更なし）

## チェックリスト

- [ ] siderをパスした
- [x] インテグレーションテストを追加した（E2E: ソートトグル・登録日時表示・検索フォーム・パラメータ保持）
- [ ] Lint のチェックをパスした
- [x] ユニットテストをパスした（CT: AdminUserRow・AdminUserSortHeader 13件）
- [ ] 必要なドキュメントを作成した

## コメント

- `AdminUserSortHeader` は Client Component として実装。`currentSort=undefined`（パラメータなし）の場合もアイコンを常時表示し、バックエンドデフォルト（降順）と一致させています。
- href 構築に `URLSearchParams` を使用し、検索クエリに特殊文字が含まれても安全にエンコードします。
- 日付フォーマットは ISO 文字列の先頭10文字をスライスして `/` 置換する方式を採用（`new Date()` はタイムゾーンずれの恐れがあるため不使用）。
- `TableSortLabel` に `component={Link}` を渡すことで `button > a` の不正ネストを回避しています。