### PR TITLE
fix: E2E カバレッジ閾値チェックを CI 独立ステップに切り出す (#89)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
         with:
           name: coverage-e2e-chromium
           path: coverage-reports/e2e
+      - name: Check coverage thresholds
+        run: node scripts/check-coverage.mjs
       # 注意: このレポートにはソースコードが埋め込まれる。リポジトリを public 化する場合は
       # artifact の公開範囲についても見直すこと
       - uses: actions/upload-artifact@v4

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         outputFile: "./coverage-reports/e2e/index.html",
         coverage: {
           outputDir: "./coverage-reports/e2e/v8",
-          reports: ["v8", "console-summary", "raw"],
+          reports: ["v8", "console-summary", "raw", "json-summary"],
           // monocart の entryFilter/sourceFilter はオブジェクトキーの定義順で
           // 先勝ち判定（最初にマッチしたキーの値が採用される）。順序を変えないこと。
           // E2E は Next.js のページ全体（ページ本体・外部スクリプト等）が対象に
@@ -50,33 +50,6 @@ export default defineConfig({
             "tests": false,
             "app/": true,
             "theme.ts": true,
-          },
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          onEnd: (results: any) => {
-            const thresholds = {
-              statements: 80,
-              branches: 80,
-              functions: 80,
-              lines: 80,
-            };
-            const errors: string[] = [];
-            const { summary } = results;
-            for (const [metric, threshold] of Object.entries(thresholds)) {
-              const pct = summary[metric]?.pct;
-              if (pct === undefined) {
-                errors.push(`Coverage metric "${metric}" not found in summary`);
-                continue;
-              }
-              if (pct < threshold) {
-                errors.push(
-                  `Coverage threshold for ${metric} (${pct}%) not met: ${threshold}%`,
-                );
-              }
-            }
-            if (errors.length) {
-              console.error(errors.join("\n"));
-              process.exitCode = 1;
-            }
           },
         },
       },

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -1,0 +1,43 @@
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const summaryPath = resolve(
+  __dirname,
+  "../coverage-reports/e2e/v8/coverage-summary.json",
+);
+
+const THRESHOLD = 80;
+const METRICS = ["statements", "branches", "functions", "lines"];
+
+let summary;
+try {
+  summary = JSON.parse(readFileSync(summaryPath, "utf-8"));
+} catch {
+  console.error(`Failed to read coverage summary: ${summaryPath}`);
+  process.exit(1);
+}
+
+const totals = summary.total;
+const errors = [];
+
+for (const metric of METRICS) {
+  const pct = totals?.[metric]?.pct;
+  if (pct === undefined) {
+    errors.push(`Coverage metric "${metric}" not found in summary`);
+    continue;
+  }
+  if (pct < THRESHOLD) {
+    errors.push(
+      `Coverage threshold for ${metric} (${pct}%) not met: ${THRESHOLD}%`,
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+
+console.log(`All coverage thresholds met (>= ${THRESHOLD}%)`);

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -20,8 +20,19 @@ try {
 }
 
 const totals = summary.total;
-const errors = [];
 
+const nf = (n) => Number(n).toLocaleString("en-US");
+const pf = (n) => `${Number(n).toFixed(2)} %`;
+
+const rows = METRICS.map((metric) => {
+  const { total, covered, pct } = totals[metric] ?? {};
+  const uncovered = total - covered;
+  return [capitalize(metric), pf(pct), nf(covered), nf(uncovered), nf(total)];
+});
+
+console.log(renderTable(["Name", "Coverage %", "Covered", "Uncovered", "Total"], rows));
+
+const errors = [];
 for (const metric of METRICS) {
   const pct = totals?.[metric]?.pct;
   if (pct === undefined) {
@@ -41,3 +52,38 @@ if (errors.length > 0) {
 }
 
 console.log(`All coverage thresholds met (>= ${THRESHOLD}%)`);
+
+function capitalize(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function renderTable(headers, rows) {
+  const allRows = [headers, ...rows];
+  const colCount = headers.length;
+
+  const widths = Array.from({ length: colCount }, (_, i) =>
+    Math.max(...allRows.map((r) => String(r[i]).length)),
+  );
+
+  const hr = (l, m, r) =>
+    l + widths.map((w) => "─".repeat(w + 2)).join(m) + r;
+
+  const dataRow = (cells) =>
+    "│" +
+    cells
+      .map((c, i) =>
+        i === 0
+          ? ` ${String(c).padEnd(widths[i])} `
+          : ` ${String(c).padStart(widths[i])} `,
+      )
+      .join("│") +
+    "│";
+
+  return [
+    hr("┌", "┬", "┐"),
+    dataRow(headers),
+    hr("├", "┼", "┤"),
+    ...rows.map(dataRow),
+    hr("└", "┴", "┘"),
+  ].join("\n");
+}


### PR DESCRIPTION
## 概要

Closes #89

E2E カバレッジ閾値チェックが Playwright の exit code に依存していたため、テスト全成功時にチェックが無効化される問題を修正。

**根本原因**: `playwright.config.ts` の `onEnd` で `process.exitCode = 1` をセットしても、Playwright がテスト成功時に exit 0 で上書きするため、カバレッジ低下を CI が検知できなかった。

**対処**: 閾値チェックを Playwright の exit code から切り離し、CI の独立ステップとして実行するよう変更。

### 変更内容

- `playwright.config.ts`: `json-summary` レポートを追加（`coverage-reports/e2e/v8/coverage-summary.json` を生成）。閾値判定していた `onEnd` ブロックを撤去。
- `scripts/check-coverage.mjs`（新規）: `coverage-summary.json` を読み込み、statements / branches / functions / lines の pct を 80% と比較。未達なら `exit 1`。
- `.github/workflows/ci.yml`: `coverage` ジョブに `node scripts/check-coverage.mjs` ステップを追加。

## 確認方法

1. このブランチで CI を実行し、カバレッジが 80% 以上あれば `coverage` ジョブが green になることを確認
2. 閾値未達の状態（テスト成功）でも `coverage` ジョブが red になることを確認（CI で回帰確認）

## 影響範囲

- E2E テストのカバレッジ閾値判定ロジックのみ（テスト自体・閾値の値・カバレッジ計測対象は変更なし）
- `playwright.config.ts` の `onEnd` を撤去したため、ローカルでの `process.exitCode` 副作用がなくなる

## チェックリスト

- [ ] Lint のチェックをパスした
- [ ] CI で coverage ジョブが正しく動作することを確認した

## コメント

`json-summary` の出力先は `coverage-reports/e2e/v8/coverage-summary.json`（monocart-coverage-reports の `outputDir` 配下）。`e2etest` ジョブの chromium artifact に含まれるため、`coverage` ジョブの Download 後に読み取り可能。