### PR TITLE
feat: 保存した算額カードの作成者名からプロフィールへのリンクを追加 #88

### DIFF
--- a/app/lib/definitions.ts
+++ b/app/lib/definitions.ts
@@ -14,7 +14,7 @@ export type Sangaku = {
       data: {
         id: string;
         type: "user";
-      };
+      } | null;
     };
     shrine: {
       data: {

--- a/app/ui/answer/SavedSangaku.tsx
+++ b/app/ui/answer/SavedSangaku.tsx
@@ -1,7 +1,7 @@
 import { Sangaku } from "@/app/lib/definitions";
 import Ema from "@/app/ui/Ema";
 import Grid from "@mui/material/Grid2";
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Button, Tooltip, Typography } from "@mui/material";
 import { difficultyTranslation } from "../utility";
 import Link from "next/link";
 import { profilePath } from "@/routes";
@@ -56,12 +56,24 @@ export default function SavedSangaku({ sangaku, answered }: Props) {
                 textOverflow: "ellipsis",
                 whiteSpace: "pre-line",
                 alignContent: "center",
+                "& a": {
+                  color: "inherit",
+                  textDecoration: "none",
+                  "&:hover": {
+                    textDecoration: "underline",
+                    color: "text.secondary",
+                  },
+                },
               }}
             >
               {sangaku.relationships.user.data?.id ? (
-                <Link href={profilePath(sangaku.relationships.user.data.id)}>
-                  {sangaku.attributes.author_name}
-                </Link>
+                <Tooltip title="プロフィールを見る" arrow>
+                  <span>
+                    <Link href={profilePath(sangaku.relationships.user.data.id)}>
+                      {sangaku.attributes.author_name}
+                    </Link>
+                  </span>
+                </Tooltip>
               ) : (
                 sangaku.attributes.author_name
               )}

--- a/app/ui/answer/SavedSangaku.tsx
+++ b/app/ui/answer/SavedSangaku.tsx
@@ -4,13 +4,14 @@ import Grid from "@mui/material/Grid2";
 import { Box, Button, Typography } from "@mui/material";
 import { difficultyTranslation } from "../utility";
 import Link from "next/link";
+import { profilePath } from "@/routes";
 
 interface Props {
   sangaku: Sangaku;
-  answerd?: boolean;
+  answered?: boolean;
 }
 
-export default function SavedSangaku({ sangaku, answerd }: Props) {
+export default function SavedSangaku({ sangaku, answered }: Props) {
   return (
     <Grid key={sangaku.id}>
       <Ema width={18}>
@@ -45,6 +46,7 @@ export default function SavedSangaku({ sangaku, answerd }: Props) {
             }}
           >
             <Typography
+              component="span"
               sx={{
                 textAlign: "center",
                 overflow: "hidden",
@@ -56,7 +58,13 @@ export default function SavedSangaku({ sangaku, answerd }: Props) {
                 alignContent: "center",
               }}
             >
-              {sangaku.attributes.author_name}
+              {sangaku.relationships.user.data?.id ? (
+                <Link href={profilePath(sangaku.relationships.user.data.id)}>
+                  {sangaku.attributes.author_name}
+                </Link>
+              ) : (
+                sangaku.attributes.author_name
+              )}
             </Typography>
             <Typography
               component="p"
@@ -74,7 +82,7 @@ export default function SavedSangaku({ sangaku, answerd }: Props) {
         </Box>
       </Ema>
       <Box sx={{ display: "flex", justifyContent: "end", mt: 1 }}>
-        {answerd || (
+        {answered || (
           <Button
             variant="contained"
             href={`/saved_sangakus/${sangaku.id}/answer/create`}
@@ -83,7 +91,7 @@ export default function SavedSangaku({ sangaku, answerd }: Props) {
             算額を解く
           </Button>
         )}
-        {answerd && (
+        {answered && (
           <Button
             variant="contained"
             href={`/saved_sangakus/${sangaku.id}/answer`}

--- a/app/ui/answer/SavedSangakuList.tsx
+++ b/app/ui/answer/SavedSangakuList.tsx
@@ -47,7 +47,7 @@ export default async function SavedSangakuList({
             <SavedSangaku
               sangaku={sangaku}
               key={sangaku.id}
-              answerd={type === "answered"}
+              answered={type === "answered"}
             />
           ))}
         {sangakus.length > 0 || (

--- a/routes.ts
+++ b/routes.ts
@@ -14,3 +14,5 @@ export const apiAuthPrefix: string = "/api/auth";
 export const adminRoutePrefix: string = "/admin";
 
 export const DEFAULT_LOGIN_REDIRECT: string = "/";
+
+export const profilePath = (id: string) => `/profiles/${id}`;

--- a/tests/components/answer/SavedSangaku.spec.tsx
+++ b/tests/components/answer/SavedSangaku.spec.tsx
@@ -1,0 +1,103 @@
+import { test, expect } from "@/tests/fixtures.ct";
+import type { Sangaku } from "@/app/lib/definitions";
+import SavedSangaku from "@/app/ui/answer/SavedSangaku";
+
+const sangaku: Sangaku = {
+  id: "1",
+  type: "sangaku",
+  attributes: {
+    title: "test_title",
+    description: "test_desc",
+    source: "puts 'hi'",
+    difficulty: "normal",
+    author_name: "test_author",
+    inputs: [{ id: 1, content: "input" }],
+  },
+  relationships: {
+    user: {
+      data: {
+        id: "42",
+        type: "user",
+      },
+    },
+    shrine: {
+      data: null,
+    },
+  },
+};
+
+test.describe("SavedSangaku", () => {
+  // RED: SavedSangaku の作者名テキストがリンクになっていない（relationships.user.data.id を使用した /profiles/{id} リンクが未実装）
+  test("should allow me to see author name as a link when relationships.user.data.id exists", async ({
+    mount,
+  }) => {
+    // Act
+    const component = await mount(<SavedSangaku sangaku={sangaku} />);
+
+    // Assert
+    const authorLink = component.getByRole("link", { name: "test_author" });
+    await expect(authorLink).toBeVisible();
+  });
+
+  // RED: SavedSangaku の作者名テキストがリンクになっていない（relationships.user.data.id を使用した /profiles/{id} リンクが未実装）
+  test("should allow me to navigate to /profiles/42 when relationships.user.data.id is '42'", async ({
+    mount,
+  }) => {
+    // Act
+    const component = await mount(<SavedSangaku sangaku={sangaku} />);
+
+    // Assert
+    const authorLink = component.getByRole("link", { name: "test_author" });
+    await expect(authorLink).toHaveAttribute("href", "/profiles/42");
+  });
+
+  // RED: フォールバック未実装のため、data が undefined でも href="/profiles/undefined" のリンクが生成されうる
+  test("should allow me to see author name as text when relationships.user.data is missing", async ({
+    mount,
+  }) => {
+    // Arrange
+    const sangakuWithoutUserData = {
+      ...sangaku,
+      relationships: {
+        ...sangaku.relationships,
+        user: {
+          data: undefined,
+        },
+      },
+    } as unknown as Sangaku;
+
+    // Act
+    const component = await mount(
+      <SavedSangaku sangaku={sangakuWithoutUserData} />,
+    );
+
+    // Assert
+    await expect(component.getByText("test_author")).toBeVisible();
+  });
+
+  // RED: フォールバック未実装のため、data が undefined でも href="/profiles/undefined" のリンクが生成されうる
+  test("should not allow me to see a profile link when relationships.user.data is missing", async ({
+    mount,
+  }) => {
+    // Arrange
+    const sangakuWithoutUserData = {
+      ...sangaku,
+      relationships: {
+        ...sangaku.relationships,
+        user: {
+          data: undefined,
+        },
+      },
+    } as unknown as Sangaku;
+
+    // Act
+    const component = await mount(
+      <SavedSangaku sangaku={sangakuWithoutUserData} />,
+    );
+
+    // Assert
+    await expect(
+      component.getByRole("link", { name: "test_author" }),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/saved_sangakus/page.spec.ts
+++ b/tests/e2e/saved_sangakus/page.spec.ts
@@ -289,5 +289,44 @@ test.describe("/saved_sangakus", () => {
       await page.getByRole("option", { name: "全て" }).click();
       await expect(page).not.toHaveURL(/difficulty=/, { timeout: 3_000 });
     });
+
+    // RED: SavedSangaku の作者名テキストがリンクになっていないため、クリックによる /profiles/1 への遷移が発生しない
+    test("should allow me to navigate to author profile page when clicking author name link", async ({
+      page,
+      msw,
+    }) => {
+      // Arrange
+      msw.use(
+        http.get(`${apiUrl}/api/v1/profiles/1`, () => {
+          return HttpResponse.json(
+            {
+              data: {
+                id: "1",
+                type: "profile",
+                attributes: {
+                  nickname: "another_user",
+                  created_at: "2026-01-01T00:00:00.000Z",
+                  sangaku_count: 0,
+                  dedicated_sangaku_count: 0,
+                  answer_count: null,
+                  dedicated_sangakus: [],
+                },
+              },
+            },
+            { status: 200 },
+          );
+        }),
+      );
+      await setSession(page);
+      await page.goto("/saved_sangakus");
+      const authorLink = page.getByRole("link", { name: "another_user" });
+      await expect(authorLink).toBeVisible({ timeout: 10_000 }); // 要素ロード待ち
+
+      // Act
+      await authorLink.click();
+
+      // Assert
+      await expect(page).toHaveURL("/profiles/1", { timeout: 10_000 });
+    });
   });
 });


### PR DESCRIPTION
## 概要

保存した算額一覧（`/saved_sangakus`）のカードに表示される作成者名を、その作成者のプロフィールページ（`/profiles/{user_id}`）へのリンクとしてリンク化しました。

closes #88

## 変更内容

- `routes.ts` に `profilePath(id)` ヘルパーを追加（パス管理を一元化）
- `SavedSangaku.tsx` の作成者名を `next/link` でリンク化
  - `relationships.user.data.id` が欠落する場合はテキスト表示にフォールバック
  - `<Typography component="span">` に変更（インライン要素として正しくネスト）
- `Sangaku` 型の `relationships.user.data` を `| null` 許容に修正
- `answerd` typo を `answered` に修正（`SavedSangaku` / `SavedSangakuList`）

## 確認方法

1. `/saved_sangakus` にアクセスし、算額カードの作成者名がリンクになっていることを確認
2. 作成者名をクリックして `/profiles/{user_id}` に遷移できることを確認

## 影響範囲

- `SavedSangaku` コンポーネント（`/saved_sangakus` 画面のカード表示）
- `Sangaku` 型定義（`relationships.user.data` が null 許容になったため、参照箇所はオプショナルチェーンが必要）

## チェックリスト

- [x] コンポーネントテストを追加した（390 passed）
- [x] E2E テストを追加した（462 passed）
- [ ] Lint のチェックをパスした

## コメント

`answerd` という既存の typo も今回あわせて修正しています（`SavedSangaku` / `SavedSangakuList` の prop 名）。