### PR TITLE
fix: 解答済み算額への重複解答時に409エラーの分かりやすいメッセージを表示する

### DIFF
--- a/app/lib/actions/answer.ts
+++ b/app/lib/actions/answer.ts
@@ -54,6 +54,12 @@ export const createAnswer = async (sangaku_id: string, source: string) => {
           errors: Object.fromEntries(data.errors),
           message: "入力に誤りがあります",
         } as State;
+      case 409:
+        await setFlash({
+          type: "error",
+          message: "この算額にはすでに解答済みです",
+        });
+        return { message: "この算額にはすでに解答済みです" } as State;
       default:
         await setFlash({ type: "error", message: "リクエストに失敗しました" });
         return { message: "リクエストに失敗しました" } as State;

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -299,7 +299,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
       await expect(errorMessage).toBeVisible();
     });
 
-    test("should show a clear error message when the sangaku is already answered", async ({
+    test("should not allow me to submit an answer for an already-answered sangaku", async ({
       page,
       msw,
     }) => {

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -298,5 +298,38 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
       const errorMessage = page.getByLabel("sourceError");
       await expect(errorMessage).toBeVisible();
     });
+
+    test("should show a clear error message when the sangaku is already answered", async ({
+      page,
+      msw,
+    }) => {
+      msw.use(
+        http.post(`${apiUrl}/api/v1/user/sangakus/1/answers`, () => {
+          return HttpResponse.json(
+            { message: "Conflict" },
+            { status: 409 },
+          );
+        }),
+      );
+      await setSession(page);
+      await page.goto("/saved_sangakus/1/answer/create");
+      const monacoEditor = page.getByTestId("monaco-editor-source").locator(".monaco-editor");
+      await waitForMonacoEditor(page);
+      await monacoEditor.click();
+      await page.keyboard.press("ControlOrMeta+a");
+      await page.keyboard.press("Backspace");
+      await page.keyboard.type("input = gets.chomp");
+      await page.keyboard.press("Enter");
+      await page.keyboard.press("Enter");
+      await page.keyboard.type("puts input");
+      const button = page.getByRole("button", { name: "解答を終了する" });
+      page.once("dialog", async (dialog) => {
+        await dialog.accept();
+      });
+      await button.click();
+      const flash = page.getByTestId("flash-message");
+      await expect(flash).toBeVisible({ timeout: 10_000 });
+      await expect(flash).toContainText("この算額にはすでに解答済みです");
+    });
   });
 });


### PR DESCRIPTION
## 概要

back#282（算額の重複保存で500エラーになる）のレビューで切り出された、front側 `createAnswer`（`app/lib/actions/answer.ts`）の409エラーハンドリング改善。

現状の `createAnswer` は `switch (res.status)` で 200 / 401 / 400 のみ個別処理しており、409は `default` 節に落ちて「リクエストに失敗しました」という汎用エラーメッセージになっていた。

back#280の修正で「解答済み算額の解答作成ページへの到達」自体は防がれる想定だが、直接URLアクセス等で到達し重複解答リクエストが送られた場合に備え、防御的にfront側でも409を個別処理し、「この算額にはすでに解答済みです」というメッセージを表示するようにした。

Closes #96

## 確認方法

1. `/saved_sangakus/[id]/answer/create` で解答を送信する
2. バックエンドが409を返すケース（既に解答済みの算額に対する重複解答リクエスト）で、「この算額にはすでに解答済みです」というフラッシュメッセージが表示されることを確認する

## 影響範囲

- `app/lib/actions/answer.ts` の `createAnswer` のエラーハンドリングのみ。他のエンドポイント・他コンポーネントへの影響なし。

## チェックリスト

- [x] Lint のチェックをパスした
- [x] E2Eテスト（409ケース）を追加し、パスすることを確認した
- [x] 既存のE2Eテスト（answer関連）にリグレッションがないことを確認した

## コメント

同様の409ハンドリング改善として front#97（`createSangakuSave` / `app/lib/actions/shrine.ts`）も別PRで対応します。