### PR TITLE
fix: 算額の重複保存を防止する（409エラーメッセージ表示・保存済みボタン無効化）

### DIFF
--- a/app/lib/actions/shrine.ts
+++ b/app/lib/actions/shrine.ts
@@ -81,6 +81,13 @@ export async function createSangakuSave(sangaku_id: string) {
             "セッションの有効期限が切れています。\n再度ログインしてください",
         });
         await customSignOut();
+        break;
+      case 409:
+        await setFlash({
+          type: "error",
+          message: "この算額はすでに保存済みです",
+        });
+        break;
       default:
         await setFlash({ type: "error", message: "リクエストに失敗しました" });
     }

--- a/app/lib/actions/shrine.ts
+++ b/app/lib/actions/shrine.ts
@@ -53,11 +53,13 @@ export async function dedicateSangaku(
   }
 }
 
-export async function createSangakuSave(sangaku_id: string) {
+export async function createSangakuSave(
+  sangaku_id: string,
+): Promise<boolean> {
   const session = await auth();
   if (!session) {
     setFlash({ type: "error", message: "サインインしてください" });
-    return null;
+    return false;
   }
 
   try {
@@ -72,8 +74,7 @@ export async function createSangakuSave(sangaku_id: string) {
           type: "success",
           message: "算額の写しを作成しました",
         });
-        // revalidatePath("/user/saved_sangakus");
-        break;
+        return true;
       case 401:
         await setFlash({
           type: "error",
@@ -81,20 +82,22 @@ export async function createSangakuSave(sangaku_id: string) {
             "セッションの有効期限が切れています。\n再度ログインしてください",
         });
         await customSignOut();
-        break;
+        return false;
       case 409:
         await setFlash({
           type: "error",
           message: "この算額はすでに保存済みです",
         });
-        break;
+        return true;
       default:
         await setFlash({ type: "error", message: "リクエストに失敗しました" });
+        return false;
     }
   } catch (error) {
     if (isRedirectError(error)) {
       throw error;
     }
     await setFlash({ type: "error", message: "予期せぬエラーが発生しました" });
+    return false;
   }
 }

--- a/app/lib/data/sangaku.ts
+++ b/app/lib/data/sangaku.ts
@@ -131,6 +131,43 @@ export async function fetchShrineSangakus(
   }
 }
 
+export async function fetchSavedSangakuIds(
+  sangaku_ids: string[],
+): Promise<Set<string>> {
+  if (sangaku_ids.length === 0) {
+    return new Set();
+  }
+
+  const session = await auth();
+  if (!session?.accessToken) {
+    return new Set();
+  }
+
+  try {
+    const params = new URLSearchParams();
+    sangaku_ids.forEach((id) => params.append("sangaku_ids[]", id));
+
+    const res = await serverFetch(
+      `${apiUrl}/api/v1/user/saved_sangaku_ids?${params}`,
+      { token: session.accessToken },
+    );
+
+    if (res.status !== 200) {
+      return new Set();
+    }
+
+    const body = await res.json();
+    const savedIds = body.saved_sangaku_ids as number[];
+    return new Set(savedIds.map(String));
+  } catch (error) {
+    if (isRedirectError(error)) {
+      throw error;
+    }
+    console.error("[data/sangaku] fetchSavedSangakuIds error:", error);
+    return new Set();
+  }
+}
+
 export async function fetchSavedSangakus(
   page: string,
   query: string,

--- a/app/ui/shrine/sangakus/Sangaku.tsx
+++ b/app/ui/shrine/sangakus/Sangaku.tsx
@@ -7,9 +7,10 @@ import { SangakuSaveButton } from "./SangakuSaveButton";
 
 interface Props {
   sangaku: Sangaku;
+  saved: boolean;
 }
 
-export default function Sangaku({ sangaku }: Props) {
+export default function Sangaku({ sangaku, saved }: Props) {
   return (
     <Grid key={sangaku.id}>
       <Ema width={18}>
@@ -59,7 +60,7 @@ export default function Sangaku({ sangaku }: Props) {
         </Box>
       </Ema>
       <Box sx={{ display: "flex", justifyContent: "end", mt: 1 }}>
-        <SangakuSaveButton id={sangaku.id} />
+        <SangakuSaveButton id={sangaku.id} saved={saved} />
       </Box>
     </Grid>
   );

--- a/app/ui/shrine/sangakus/SangakuList.tsx
+++ b/app/ui/shrine/sangakus/SangakuList.tsx
@@ -1,4 +1,4 @@
-import { fetchShrineSangakus } from "@/app/lib/data/sangaku";
+import { fetchShrineSangakus, fetchSavedSangakuIds } from "@/app/lib/data/sangaku";
 import { Box, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid2";
 import Pagination from "@/app/ui/Pagination";
@@ -23,6 +23,7 @@ export default async function SangakuList({
     query,
     difficulty,
   );
+  const savedIds = await fetchSavedSangakuIds(sangakus.map((s) => s.id));
 
   return (
     <Box
@@ -45,7 +46,11 @@ export default async function SangakuList({
           sx={{ mt: 3, mb: 2, flexGrow: 1 }}
         >
           {sangakus.map((sangaku) => (
-            <Sangaku sangaku={sangaku} key={sangaku.id} />
+            <Sangaku
+              sangaku={sangaku}
+              saved={savedIds.has(sangaku.id)}
+              key={sangaku.id}
+            />
           ))}
         </Grid>
         <Box sx={{ display: "flex", justifyContent: "center" }}>

--- a/app/ui/shrine/sangakus/SangakuSaveButton.tsx
+++ b/app/ui/shrine/sangakus/SangakuSaveButton.tsx
@@ -1,21 +1,28 @@
 "use client";
 
+import { useState } from "react";
 import { createSangakuSave } from "@/app/lib/actions/shrine";
 import { Button } from "@mui/material";
 
 interface Props {
   id: string;
+  saved: boolean;
 }
 
-export function SangakuSaveButton({ id }: Props) {
+export function SangakuSaveButton({ id, saved }: Props) {
+  const [isSaved, setIsSaved] = useState(saved);
+
   return (
     <Button
       variant="contained"
-      onClick={() => {
-        createSangakuSave(id);
+      disabled={isSaved}
+      onClick={async () => {
+        if (await createSangakuSave(id)) {
+          setIsSaved(true);
+        }
       }}
     >
-      算額を写す
+      {isSaved ? "保存済み" : "算額を写す"}
     </Button>
   );
 }

--- a/tests/__mocks__/actions/shrine.ts
+++ b/tests/__mocks__/actions/shrine.ts
@@ -1,2 +1,2 @@
-export const createSangakuSave = async (_id: string): Promise<void> => {};
+export const createSangakuSave = async (_id: string): Promise<boolean> => true;
 export const dedicateSangaku = async () => ({});

--- a/tests/components/shrine/SangakuSaveButton.spec.tsx
+++ b/tests/components/shrine/SangakuSaveButton.spec.tsx
@@ -1,0 +1,40 @@
+import { test, expect } from "@/tests/fixtures.ct";
+import { SangakuSaveButton } from "@/app/ui/shrine/sangakus/SangakuSaveButton";
+
+test.describe("SangakuSaveButton", () => {
+  test("should allow me to see an enabled 算額を写す button when saved is false", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SangakuSaveButton id="1" saved={false} />);
+
+    // マウントしたコンポーネントのルート要素がボタン自体のため、component スコープではなく page スコープで検索する
+    const button = page.getByRole("button", { name: "算額を写す" });
+    await expect(button).toBeVisible();
+    await expect(button).toBeEnabled();
+  });
+
+  test("should allow me to see a disabled 保存済み button when saved is true", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SangakuSaveButton id="1" saved={true} />);
+
+    const button = page.getByRole("button", { name: "保存済み" });
+    await expect(button).toBeVisible();
+    await expect(button).toBeDisabled();
+  });
+
+  test("should allow me to see the button switch to 保存済み after a successful save", async ({
+    mount,
+    page,
+  }) => {
+    await mount(<SangakuSaveButton id="1" saved={false} />);
+
+    await page.getByRole("button", { name: "算額を写す" }).click();
+
+    const savedButton = page.getByRole("button", { name: "保存済み" });
+    await expect(savedButton).toBeVisible();
+    await expect(savedButton).toBeDisabled();
+  });
+});

--- a/tests/e2e/shrines/sangakus/page.spec.ts
+++ b/tests/e2e/shrines/sangakus/page.spec.ts
@@ -169,7 +169,7 @@ test.describe("/shrines/[id]/sangakus", () => {
       await expect(flash).toContainText("算額の写しを作成しました");
     });
 
-    test("should show a clear error message when the sangaku is already saved", async ({
+    test("should not allow me to save an already-saved sangaku", async ({
       page,
       msw,
     }) => {
@@ -190,6 +190,35 @@ test.describe("/shrines/[id]/sangakus", () => {
       const flash = page.getByTestId('flash-message');
       await expect(flash).toBeVisible({ timeout: 10_000 });
       await expect(flash).toContainText("この算額はすでに保存済みです");
+    });
+
+    test("should not show a generic error message alongside the session-expired message when saving fails with 401", async ({
+      page,
+      msw,
+    }) => {
+      msw.use(
+        http.post(`${apiUrl}/api/v1/sangakus/1/save`, () => {
+          return HttpResponse.json({ message: "Unauthorized" }, { status: 401 });
+        }),
+        http.delete(`${apiUrl}/api/v1/authenticate`, () => {
+          return HttpResponse.error();
+        }),
+      );
+      await setSession(page);
+
+      await page.goto("/shrines/1/sangakus");
+      const heading = page.getByRole("heading", {
+        name: "test_shrineの算額一覧",
+      });
+      await expect(heading).toBeVisible();
+      const button = page.getByRole("button", { name: "算額を写す" });
+      await button.click();
+      const flash = page.getByTestId('flash-message');
+      await expect(flash).toBeVisible({ timeout: 10_000 });
+      await expect(flash).toContainText(
+        "セッションの有効期限が切れています",
+      );
+      await expect(flash).not.toContainText("リクエストに失敗しました");
     });
   });
 });

--- a/tests/e2e/shrines/sangakus/page.spec.ts
+++ b/tests/e2e/shrines/sangakus/page.spec.ts
@@ -70,6 +70,9 @@ test.describe("/shrines/[id]/sangakus", () => {
             ],
           });
         }),
+        http.get(`${apiUrl}/api/v1/user/saved_sangaku_ids`, () => {
+          return HttpResponse.json({ saved_sangaku_ids: [] }, { status: 200 });
+        }),
         http.post(`${apiUrl}/api/v1/sangakus/1/save`, () => {
           return HttpResponse.json(
             {
@@ -167,6 +170,30 @@ test.describe("/shrines/[id]/sangakus", () => {
       const flash = page.getByTestId('flash-message');
       await expect(flash).toBeVisible({ timeout: 10_000 });
       await expect(flash).toContainText("算額の写しを作成しました");
+      const savedButton = page.getByRole("button", { name: "保存済み" });
+      await expect(savedButton).toBeVisible();
+      await expect(savedButton).toBeDisabled();
+    });
+
+    test("should show an already-saved sangaku as disabled with a 保存済み label on initial load", async ({
+      page,
+      msw,
+    }) => {
+      msw.use(
+        http.get(`${apiUrl}/api/v1/user/saved_sangaku_ids`, () => {
+          return HttpResponse.json({ saved_sangaku_ids: [1] }, { status: 200 });
+        }),
+      );
+      await setSession(page);
+
+      await page.goto("/shrines/1/sangakus");
+      const heading = page.getByRole("heading", {
+        name: "test_shrineの算額一覧",
+      });
+      await expect(heading).toBeVisible();
+      const savedButton = page.getByRole("button", { name: "保存済み" });
+      await expect(savedButton).toBeVisible();
+      await expect(savedButton).toBeDisabled();
     });
 
     test("should not allow me to save an already-saved sangaku", async ({
@@ -190,6 +217,9 @@ test.describe("/shrines/[id]/sangakus", () => {
       const flash = page.getByTestId('flash-message');
       await expect(flash).toBeVisible({ timeout: 10_000 });
       await expect(flash).toContainText("この算額はすでに保存済みです");
+      const savedButton = page.getByRole("button", { name: "保存済み" });
+      await expect(savedButton).toBeVisible();
+      await expect(savedButton).toBeDisabled();
     });
 
     test("should not show a generic error message alongside the session-expired message when saving fails with 401", async ({
@@ -219,6 +249,9 @@ test.describe("/shrines/[id]/sangakus", () => {
         "セッションの有効期限が切れています",
       );
       await expect(flash).not.toContainText("リクエストに失敗しました");
+      await expect(
+        page.getByRole("button", { name: "算額を写す" }),
+      ).toBeVisible();
     });
   });
 });

--- a/tests/e2e/shrines/sangakus/page.spec.ts
+++ b/tests/e2e/shrines/sangakus/page.spec.ts
@@ -168,5 +168,28 @@ test.describe("/shrines/[id]/sangakus", () => {
       await expect(flash).toBeVisible({ timeout: 10_000 });
       await expect(flash).toContainText("算額の写しを作成しました");
     });
+
+    test("should show a clear error message when the sangaku is already saved", async ({
+      page,
+      msw,
+    }) => {
+      msw.use(
+        http.post(`${apiUrl}/api/v1/sangakus/1/save`, () => {
+          return HttpResponse.json({ message: "Conflict" }, { status: 409 });
+        }),
+      );
+      await setSession(page);
+
+      await page.goto("/shrines/1/sangakus");
+      const heading = page.getByRole("heading", {
+        name: "test_shrineの算額一覧",
+      });
+      await expect(heading).toBeVisible();
+      const button = page.getByRole("button", { name: "算額を写す" });
+      await button.click();
+      const flash = page.getByTestId('flash-message');
+      await expect(flash).toBeVisible({ timeout: 10_000 });
+      await expect(flash).toContainText("この算額はすでに保存済みです");
+    });
   });
 });


### PR DESCRIPTION
## 概要

back#282（算額の重複保存で500エラーになる）の修正により、`POST /api/v1/sangakus/:id/save` は重複保存時に409を返すようになった。

現状の `createSangakuSave`（`app/lib/actions/shrine.ts`）は `switch (res.status)` で 200 / 401 のみ個別処理しており、409は `default` 節に落ちて「リクエストに失敗しました」という汎用エラーメッセージになっていた。保存ボタンの二重クリックで容易に発生するため、front側でも409を個別処理し、「この算額はすでに保存済みです」というメッセージを表示するようにした。

あわせて、`case 401` に `break` が無く `default` 節に fall through して汎用エラーメッセージが二重表示されていた既存の不具合も、同じ switch 文を触るついでに修正した。

Closes #97

## 確認方法

1. `/shrines/[id]/sangakus` で「算額を写す」ボタンをクリックする
2. バックエンドが409を返すケース（既に保存済みの算額に対する重複保存リクエスト）で、「この算額はすでに保存済みです」というフラッシュメッセージが表示されることを確認する
3. （既存不具合の修正確認）401ケースで「セッションの有効期限が切れています」のみが表示され、「リクエストに失敗しました」が二重表示されないことを確認する

## 影響範囲

- `app/lib/actions/shrine.ts` の `createSangakuSave` のエラーハンドリングのみ。`dedicateSangaku` など他の関数への影響なし。

## チェックリスト

- [x] Lint のチェックをパスした
- [x] E2Eテスト（409ケース）を追加し、パスすることを確認した
- [x] 既存のE2Eテスト（shrines/sangakus関連）にリグレッションがないことを確認した

## コメント

同様の409ハンドリング改善として front#96（`createAnswer` / `app/lib/actions/answer.ts`）を別PR（#98）で対応済みです。