### PR TITLE
Vercel本番デプロイを親リポ起点のworkflow_dispatchに切り替える

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,99 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Deploy対象のコミットSHA（main に含まれる40桁フルSHA）"
+        required: true
+        type: string
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  checks: read
+  statuses: write
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+jobs:
+  deploy:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Validate sha format
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          [[ "$INPUT_SHA" =~ ^[0-9a-f]{40}$ ]] \
+            || { echo "::error::sha must be a full 40-character lowercase commit SHA"; exit 1; }
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Ensure sha is contained in main
+        env:
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          git merge-base --is-ancestor "$INPUT_SHA" origin/main \
+            || { echo "::error::$INPUT_SHA is not an ancestor of main"; exit 1; }
+          git checkout --detach "$INPUT_SHA"
+
+      - name: Verify CI passed for sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_SHA: ${{ inputs.sha }}
+        run: |
+          failing=$(gh api "repos/${{ github.repository }}/commits/$INPUT_SHA/check-runs" \
+            --jq '[.check_runs[] | select(.conclusion != "success")] | length')
+          if [ "$failing" -gt 0 ]; then
+            echo "::error::CI has not passed (or is incomplete) for $INPUT_SHA"
+            exit 1
+          fi
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install pnpm
+        run: npm install -g pnpm@10.0.0
+      - name: Install Vercel CLI
+        run: npm install -g vercel@58.0.0
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production
+      - name: Build Project Artifacts
+        run: vercel build --prod
+      - name: Deploy Project Artifacts to Vercel
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --prod)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Health check
+        run: curl -fsS --retry 5 --retry-delay 5 --retry-connrefused "${{ steps.deploy.outputs.url }}" > /dev/null
+
+      - name: Report deployment status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_SHA: ${{ inputs.sha }}
+          RESULT: ${{ job.status }}
+        run: |
+          if [ "$RESULT" = "success" ]; then
+            state="success"
+            description="Deployed to production"
+          else
+            state="failure"
+            description="Deployment failed"
+          fi
+          gh api "repos/${{ github.repository }}/statuses/$INPUT_SHA" \
+            -f state="$state" -f context="deploy/vercel-production" -f description="$description"

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## 概要

front リポジトリ自身の main への push によるVercel Git連携の自動本番デプロイを廃止し、`workflow_dispatch(sha)` を起点とした本番デプロイに切り替える。

親リポジトリ（`algo_sangaku`）の main マージを本番デプロイの唯一のトリガーにするという設計変更（親issue [algo_sangaku#38](https://github.com/Alnoir-0011/algo_sangaku/issues/38)）の front 担当分。詳細仕様は #100 を参照。

- `vercel.json` を新規追加し、`git.deploymentEnabled.main: false` により main への push での自動デプロイのみ無効化（Preview Deploymentは維持）
- `.github/workflows/deploy.yml` を新規追加。`workflow_dispatch(inputs.sha)` で指定されたコミットを、以下の検証を経てVercel本番環境にデプロイする
  - `sha` が40桁フルコミットSHAであることの形式検証
  - `sha` が `main` の祖先であることの検証（forkのPRコミット等、mainに含まれない任意コードを本番にデプロイできてしまう問題を防ぐ）
  - 対象shaの `ci.yml` の check-runs が全て成功していることの確認
  - Vercel CLI（`vercel pull` → `vercel build --prod` → `vercel deploy --prebuilt --prod`）によるデプロイ。トークンはコマンドライン引数でなく環境変数で渡す
  - デプロイURLへのヘルスチェック
  - 成功/失敗をGitHub Commit Status APIで対象shaに記録

## 確認方法

このPR自体はコード変更のみで、以下はコード変更外のためユーザー側で別途対応が必要（#100 のタスクリスト参照）。

1. Vercelダッシュボードで `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` を取得する
2. front リポジトリに GitHub Environment `production` を作成し、Deployment branches を `main` のみに制限する
3. 上記3つを Environment Secrets として登録する
4. マージ後、手動で `workflow_dispatch` を実行し、Vercel production デプロイが成功することを確認する
5. front の main に軽微な変更をpushしても本番URLが更新されないことを確認する（Preview Deploymentが引き続き動作することも合わせて確認）

## 影響範囲

- 本PRマージ直後は挙動に変化なし（`vercel.json` の反映には一度デプロイが必要なため）
- 上記確認方法のSecrets登録・Environment設定が完了して初めて、main pushでの自動デプロイが止まり、workflow_dispatchでのデプロイに一本化される
- 既存の `ci.yml`（CI）には変更なし

## チェックリスト

- [x] `deploy.yml` のYAML構文チェック済み
- [x] `vercel.json` のJSON構文チェック済み
- [ ] 実際の `workflow_dispatch` 実行によるVercel本番デプロイの成功確認（Secrets登録後に別途実施）

## コメント

- 当初案はシンプルな `vercel pull/build/deploy` の3ステップのみだったが、code-reviewer / security-reviewer によるレビューで「main祖先チェックなしに任意コミットを本番デプロイできてしまう」「repository secretだと任意ブランチからのdispatchでトークンを読み取れる」などのBlocker指摘があり、対応を反映した。詳細は #100 の更新履歴を参照
- 運用ドキュメント（誰が・どうやって`workflow_dispatch`を起動するか、失敗時の対処、旧方式へのロールバック手順）は本PRには含めず、別issueとして切り出す予定