### PR TITLE
fix: deploy.ymlのCIチェック検証・出力検証・secretsスコープを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,6 @@ permissions:
   checks: read
   statuses: write
 
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
 jobs:
   deploy:
     timeout-minutes: 30
@@ -49,15 +44,41 @@ jobs:
             || { echo "::error::$INPUT_SHA is not an ancestor of main"; exit 1; }
           git checkout --detach "$INPUT_SHA"
 
+      # check-runs が 0 件（[skip ci] 等で CI 自体が実行されなかった場合）でも
+      # 空配列は無条件で合格してしまうため、必須チェック名を明示的に列挙して検証する。
+      # ci.yml のジョブ名（e2etest は matrix のため各ブラウザ名を含む）と対応させること。
       - name: Verify CI passed for sha
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_SHA: ${{ inputs.sha }}
         run: |
-          failing=$(gh api "repos/${{ github.repository }}/commits/$INPUT_SHA/check-runs" \
-            --jq '[.check_runs[] | select(.conclusion != "success")] | length')
-          if [ "$failing" -gt 0 ]; then
-            echo "::error::CI has not passed (or is incomplete) for $INPUT_SHA"
+          set -euo pipefail
+
+          successful=$(gh api --paginate "repos/${{ github.repository }}/commits/$INPUT_SHA/check-runs" \
+            --jq '.check_runs[] | select(.conclusion == "success") | .name')
+
+          if [ -z "$successful" ]; then
+            echo "::error::no successful check runs found for $INPUT_SHA"
+            exit 1
+          fi
+
+          missing=0
+          while IFS= read -r required; do
+            if ! grep -qxF "$required" <<< "$successful"; then
+              echo "::error::required check '$required' is missing or not successful"
+              missing=1
+            fi
+          done <<REQUIRED
+          build
+          lint
+          componentstest
+          coverage
+          e2etest (chromium)
+          e2etest (firefox)
+          e2etest (webkit)
+          REQUIRED
+
+          if [ "$missing" -eq 1 ]; then
             exit 1
           fi
 
@@ -68,18 +89,38 @@ jobs:
         run: npm install -g pnpm@10.0.0
       - name: Install Vercel CLI
         run: npm install -g vercel@58.0.0
+      # VERCEL_TOKEN は npm install 等のインストールステップからは見えないよう、
+      # Vercel CLI を実際に使うステップにのみ env でスコープする。
       - name: Pull Vercel Environment Information
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: vercel pull --yes --environment=production
       - name: Build Project Artifacts
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: vercel build --prod
       - name: Deploy Project Artifacts to Vercel
         id: deploy
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          url=$(vercel deploy --prebuilt --prod)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          url=$(vercel deploy --prebuilt --prod | tail -n 1)
+          if [[ ! "$url" =~ ^https://[A-Za-z0-9.-]+$ ]]; then
+            echo "::error::unexpected deploy url: $url"
+            exit 1
+          fi
+          printf 'url=%s\n' "$url" >> "$GITHUB_OUTPUT"
 
       - name: Health check
-        run: curl -fsS --retry 5 --retry-delay 5 --retry-connrefused "${{ steps.deploy.outputs.url }}" > /dev/null
+        env:
+          URL: ${{ steps.deploy.outputs.url }}
+        run: curl -fsS --retry 5 --retry-delay 5 --retry-connrefused "$URL" > /dev/null
 
       - name: Report deployment status
         if: always()


### PR DESCRIPTION
## 概要

親リポジトリ(algo_sangaku)issue #38「親リポジトリのPRマージに同期して本番環境を更新する仕組みの導入」の実装中に行った Quick Review（code-reviewer/security-reviewer）で、本リポジトリの `deploy.yml` に対して以下3点の指摘があったため対応する。

1. `Verify CI passed for sha` ステップが、対象SHAの `check-runs` が0件（コミットメッセージに `[skip ci]` を含む等でCI自体が未実行）の場合、空配列を無条件で合格として扱っていた
2. `vercel deploy` の標準出力を検証せず `${{ steps.deploy.outputs.url }}` を `run:` に直接展開しており、CLIの出力次第で出力インジェクション・コマンドインジェクションの余地があった
3. `VERCEL_TOKEN` がworkflowレベルの `env` で宣言されており、`npm install -g pnpm`/`npm install -g vercel` 等のインストールステップ（postinstall等のlifecycle script経由）からも読める状態だった

refs #100

## 確認方法

1. `Verify CI passed for sha` の差分をレビューする
   - `check_runs` が空の場合は明示的にエラーにする
   - `ci.yml` のジョブ名(`build`/`lint`/`componentstest`/`coverage`/`e2etest (chromium)`/`e2etest (firefox)`/`e2etest (webkit)`)を必須チェックとして列挙し、全て `success` であることを検証する
   - ロジック部分はローカルで4パターン（全成功/0件/一部欠落/無関係チェックのみ）を検証済み
2. `Deploy Project Artifacts to Vercel` / `Health check` の差分をレビューする
   - `vercel deploy` の出力を `https://` から始まるURL形式かバリデーションしてから `GITHUB_OUTPUT` に書き込む
   - `Health check` ステップは `${{ }}` を `run:` に直接展開せず `env:` 経由に変更
3. `VERCEL_TOKEN`/`VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` のスコープを、Vercel CLI を実際に使うステップ（`vercel pull`/`vercel build`/`vercel deploy`）のみの step-level `env` に変更したことを確認する
4. YAML構文検証済み（`ruby -ryaml`）

## 影響範囲

- `deploy.yml`（`workflow_dispatch` 経由の本番デプロイ）にのみ影響。通常のPRやmainへのpushで動く `ci.yml` には影響しない
- 必須チェック名は `ci.yml` のジョブ名に依存するため、今後 `ci.yml` のジョブが追加・改名された場合はこのワークフローの必須チェック一覧も追従が必要（コメントで明記済み）

## チェックリスト

- [x] YAML構文検証をパス
- [x] CIチェック検証ロジックをローカルで4パターン検証
- [ ] 実際に `workflow_dispatch` で動作確認（親リポのdeploy-dispatch Environment設定完了後、実リリース時に確認）

## コメント

本修正は親リポ algo_sangaku の PR #40（issue #38対応）に付随して発見されたもの

🤖 Generated with [Claude Code](https://claude.com/claude-code)