### PR TITLE
chore: 必須チェック名の同期先に main の ruleset を明記する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,10 @@ jobs:
 
       # check-runs が 0 件（[skip ci] 等で CI 自体が実行されなかった場合）でも
       # 空配列は無条件で合格してしまうため、必須チェック名を明示的に列挙して検証する。
-      # ci.yml のジョブ名（e2etest は matrix のため各ブラウザ名を含む）と対応させること。
+      # ci.yml のジョブ名（e2etest は matrix のため各ブラウザ名を含む）、および main の
+      # ruleset「protect main」の required_status_checks と一致させること。ジョブ名を変える
+      # 場合はこの3箇所すべての更新が必要で、片方だけ直すと「main にはマージできるが
+      # デプロイで弾かれる」またはその逆の状態になる。
       # 同名チェックが再実行されている場合、check-runs には新旧両方のconclusionが
       # 混在して返る。id（作成順）が最大＝最新の実行結果のみを判定対象にする。
       - name: Verify CI passed for sha


### PR DESCRIPTION
## 概要

main ブランチの ruleset「protect main」に `required_status_checks` を追加した（GitHub 上の設定変更のため本 PR にコード差分はない）。これに伴い、CI のジョブ名が **3箇所**に散らばる形になったため、`deploy.yml` のコメントに同期先を明記する。

### 背景: なぜ ruleset に required_status_checks を追加したか

親リポジトリ（algo_sangaku）の PR マージを本番デプロイの唯一のトリガーにする仕組み（#100 / #103 で対応済み）のレビューで、front の `main` に必須ステータスチェックが設定されていないことが分かった。

- back の ruleset には `scan_ruby` / `rspec` / `lint` が必須チェックとして設定済み
- front の ruleset「protect main」は `pull_request`（承認0）/ `deletion` / `non_fast_forward` のみ

この状態では CI 未通過のまま `main` にマージでき、親リポジトリの submodule ポインタ更新 PR も作れてしまう。一方 `deploy.yml` の `Verify CI passed for sha` は必須チェックの成功を要求するため、**親リポジトリ側は成功扱いなのに front だけ本番未反映**という状態が起こりうる（親リポの dispatch は fire-and-forget で完了を追跡しないため気づきにくい）。

### 設定した内容

| 項目 | 値 |
| --- | --- |
| 必須チェック | `build` / `lint` / `componentstest` / `coverage` / `e2etest (chromium)` / `e2etest (firefox)` / `e2etest (webkit)` |
| strict policy | `false`（back の `strict_required_status_checks_policy: false` と統一） |
| 既存ルール | `pull_request`（承認0）/ `deletion` / `non_fast_forward` はそのまま保持 |

必須チェックの7件は `deploy.yml` の `Verify CI passed for sha` が要求するリストと完全に一致させている。これにより「`main` にマージできた＝デプロイ時の CI 検証も通る」が保証される。

### 本 PR のコード変更

`deploy.yml` のコメントが `ci.yml` との対応にしか言及していなかったため、ruleset も同期先であることを追記する。ジョブ名を変更する際に片方だけ直すと、「`main` にはマージできるがデプロイで弾かれる」またはその逆の状態になる。

## 確認方法

1. 本 PR 自体が必須チェック7件の成功を要求されることを確認する（この PR が最初の適用対象になる）
2. `main` に適用されるルールを確認する
   ```bash
   gh api repos/Alnoir-0011/algo_sangaku_front/rules/branches/main --jq '[.[]|.type]|unique'
   # => ["deletion","non_fast_forward","pull_request","required_status_checks"]
   ```
3. `deploy.yml` の必須チェックリストと ruleset の `required_status_checks` が一致していることを確認する

## 影響範囲

- **`main` へのマージに CI 7件の成功が必須になる**。CI 未通過の PR はマージできなくなる
- strict policy は無効のため、`main` が進んでもブランチの更新・CI 再実行は要求されない
- 必須承認数は 0 のまま変更していないため、レビュー運用への影響はない
- コード変更はコメントのみで、ワークフローの挙動は変わらない
- back の ruleset とルール構成が揃った（`deletion` / `non_fast_forward` / `pull_request` / `required_status_checks`）

## チェックリスト

- [x] YAML 構文を検証した（`ruby -ryaml`）
- [x] 変更前の ruleset をバックアップしてから適用した
- [x] 適用後、既存3ルールが失われていないことを確認した
- [x] `repos/.../rules/branches/main` で実際に `main` へ適用されるルールとして評価されることを確認した
- [x] 必須チェック名が `ci.yml` の実ジョブ名（直近の `main` への push で生成された check-runs）と一致することを確認した

## コメント

- ruleset の設定は GitHub 上の操作のため、本 PR をリバートしても設定は戻らない。戻す場合は ruleset から `required_status_checks` を削除する必要がある
- 必須チェックに `e2etest` 3ブラウザ分を含めたため、PR のマージまでに CI の完了を待つ時間が長くなる。`deploy.yml` 側が同じ7件を要求しており、ここを減らすと「マージできてもデプロイで弾かれる」ズレが生じるため、あえて一致させている

🤖 Generated with [Claude Code](https://claude.com/claude-code)
