### PR TITLE
chore: GitHub Actions を Node.js 24 対応バージョンに更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Install dependencies
         run: npm install -g pnpm@10 && pnpm install
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -28,7 +28,7 @@ jobs:
         run: cp env.template .env
       - name: Run Playwright tests
         run: pnpm run test:components
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-components
@@ -39,8 +39,8 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Install dependencies
@@ -55,7 +55,7 @@ jobs:
           COVERAGE: "true"
         run: pnpm run build
       - name: Upload .next
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: next-build
           path: .next/
@@ -71,14 +71,14 @@ jobs:
       matrix:
         project: [chromium, firefox, webkit]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Install dependencies
         run: npm install -g pnpm@10 && pnpm install
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ matrix.project }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -87,7 +87,7 @@ jobs:
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps ${{ matrix.project }}
       - name: Download .next
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: next-build
           path: .next/
@@ -99,13 +99,13 @@ jobs:
         env:
           APP_ENV: test
         run: pnpm exec playwright test --project=${{ matrix.project }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-e2e-${{ matrix.project }}
           path: playwright-report/
           retention-days: 30
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() && matrix.project == 'chromium' }}
         with:
           name: coverage-e2e-chromium
@@ -117,12 +117,12 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Download E2E Chromium coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-e2e-chromium
           path: coverage-reports/e2e
@@ -130,7 +130,7 @@ jobs:
         run: node scripts/check-coverage.mjs
       # 注意: このレポートにはソースコードが埋め込まれる。リポジトリを public 化する場合は
       # artifact の公開範囲についても見直すこと
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: coverage-report
@@ -141,8 +141,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
           [[ "$INPUT_SHA" =~ ^[0-9a-f]{40}$ ]] \
             || { echo "::error::sha must be a full 40-character lowercase commit SHA"; exit 1; }
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -89,7 +89,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: lts/*
       - name: Install pnpm


### PR DESCRIPTION
## 概要

親リポジトリ（algo_sangaku）の `deploy.yml` 初回実行と front の CI 実行の双方で、Node.js 20 の非推奨警告が記録されていた。

```
[warning] Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/cache@v4, actions/checkout@v4,
actions/download-artifact@v4, actions/setup-node@v4, actions/upload-artifact@v4
```

現状は Node.js 24 で強制実行されて動作しているが、GitHub の[アナウンス](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)のとおりいずれ動かなくなる。使用中のアクションを最新のメジャーバージョンに更新する。

| アクション | 変更 | 箇所 |
| --- | --- | --- |
| `actions/checkout` | v4 → **v7** | ci.yml 5 + deploy.yml 1 |
| `actions/setup-node` | v4 → **v7** | ci.yml 5 + deploy.yml 1 |
| `actions/upload-artifact` | v4 → **v7** | ci.yml 5 |
| `actions/download-artifact` | v4 → **v8** | ci.yml 2 |
| `actions/cache` | v4 → **v6** | ci.yml 2 |

back リポジトリは既に `actions/checkout@v7` を使っており警告が出ていないため、front もその水準に揃える形になる。

## 確認方法

**本 PR の CI（必須チェック7件）が全て成功することが検証そのもの。** artifact 系はジョブ間の受け渡しに使われており、メジャーバージョン更新の影響を受けやすいため、以下が実際に通ることを確認する。

1. `build` が `.next` を `upload-artifact@v7` でアップロードできること（`include-hidden-files: true` が v7 でも有効か）
2. `e2etest`（chromium / firefox / webkit）が `download-artifact@v8` で `.next` を取得し、テストが通ること
3. `e2etest (chromium)` がカバレッジを artifact にアップロードし、`coverage` ジョブが `download-artifact@v8` で取得して閾値チェックを通過すること
4. `componentstest` / `e2etest` の Playwright ブラウザキャッシュが `cache@v6` で機能すること
5. CI 実行後、run のアノテーションから Node.js 20 非推奨警告が消えていること

`deploy.yml` は `workflow_dispatch` のみで起動するため本 PR では実行されないが、変更は `checkout` と `setup-node` のバージョンのみで、`Verify CI passed for sha` 以降のロジックには触れていない。

## 影響範囲

- ワークフロー定義のみの変更。アプリケーションコード・テストコードへの変更はなし
- `ci.yml` の必須チェック名（`build` / `lint` / `componentstest` / `coverage` / `e2etest (chromium・firefox・webkit)`）は変更していないため、main ブランチの ruleset `protect main` の `required_status_checks` および `deploy.yml` の必須リストとの整合は保たれる
- `deploy.yml` の変更は次回の本番デプロイ（親リポジトリのポインタ更新 PR のマージ）時に初めて実行される

## チェックリスト

- [x] YAML 構文検証（`ruby -ryaml`、ci.yml / deploy.yml とも OK）
- [x] `@v4` の残存がないことを確認
- [x] 各アクションの最新メジャーバージョンを確認（checkout v7.0.1 / setup-node v7.0.0 / upload-artifact v7.0.1 / download-artifact v8.0.1 / cache v6.1.0）
- [x] 必須チェック名に影響する変更がないことを確認
- [ ] CI 7件が全て成功すること（本 PR で検証）
- [ ] CI 実行後、Node.js 20 非推奨警告が消えていること（本 PR で検証）

## コメント

- artifact 系のメジャーバージョンを大きく飛ばしている（v4 → v7 / v8）。もし CI が失敗する場合は、失敗したアクションだけ段階的に上げるか、v4 に戻して個別に対応する
- 親リポジトリ側の `actions/checkout@v4` も同じ警告が出ており、Alnoir-0011/algo_sangaku#41 で対応している

🤖 Generated with [Claude Code](https://claude.com/claude-code)
