### PR TITLE
feat: レート制限のカウント先をバケットごとに分ける

### DIFF
--- a/app/lib/guard/bot.ts
+++ b/app/lib/guard/bot.ts
@@ -1,14 +1,20 @@
 export type BotClass =
-  | "verified-crawler"
+  | "claimed-crawler"
   | "seo-crawler"
   | "malicious"
   | "unknown";
 
-/** 検索・SNS の正規クローラー。公開 GET のみ許可する */
-const VERIFIED_CRAWLERS =
+/**
+ * 検索・SNS のクローラーを名乗る UA。
+ *
+ * "verified" ではなく "claimed" としているのは、逆引きや IP レンジによる
+ * 検証を一切していないため。UA に Googlebot と書けば誰でもこの分類になる。
+ * 「クローラーだから許す」という判断をこれ以上増やさないこと。
+ */
+const CLAIMED_CRAWLERS =
   /(Googlebot|bingbot|DuckDuckBot|Applebot|Slurp|YandexBot|Baiduspider|facebookexternalhit|Twitterbot|LinkedInBot)/i;
 
-/** SEO 解析クローラー。正規クローラーと同じく公開 GET のみ許可する */
+/** SEO 解析クローラー。名乗りを信じている点は上と同じ */
 const SEO_CRAWLERS = /(AhrefsBot|SemrushBot|MJ12bot|DotBot)/i;
 
 /**
@@ -24,13 +30,16 @@ const MALICIOUS_AGENTS =
 /**
  * User-Agent から Bot の種別を判定する。
  *
+ * 悪性の判定を最初に行う。クローラーの名乗りを先に見ると
+ * "curl/8.0 Googlebot" のような UA で悪性判定を回避できてしまうため。
+ *
  * 判定に使うのは UA のみ。Accept-Language の欠如は誤検知が多いため、
  * 引数として受け取らないことで構造的に判定材料から外している。
  */
 export function classifyBot(userAgent: string | null): BotClass {
   if (!userAgent) return "unknown";
-  if (VERIFIED_CRAWLERS.test(userAgent)) return "verified-crawler";
-  if (SEO_CRAWLERS.test(userAgent)) return "seo-crawler";
   if (MALICIOUS_AGENTS.test(userAgent)) return "malicious";
+  if (CLAIMED_CRAWLERS.test(userAgent)) return "claimed-crawler";
+  if (SEO_CRAWLERS.test(userAgent)) return "seo-crawler";
   return "unknown";
 }

--- a/app/lib/guard/index.ts
+++ b/app/lib/guard/index.ts
@@ -3,6 +3,7 @@ import { getClientIp } from "./ip";
 import {
   checkLimit,
   createLimiter,
+  createMemoryLimiter,
   type Limiter,
   type LimiterConfig,
 } from "./ratelimit";
@@ -62,16 +63,31 @@ type Identity = {
 
 const ONE_MINUTE_MS = 60_000;
 
+type BucketConfig = LimiterConfig & {
+  /**
+   * true なら Upstash（アイソレート間で共有・正確）、false ならインメモリ
+   * （アイソレート単位・近似）でカウントする。
+   */
+  shared: boolean;
+};
+
 /**
- * 経路グループごとのしきい値。
+ * 経路グループごとのしきい値とカウント先。
  *
- * すべて仮の初期値であり、shadow での観測を経てから調整する。
+ * しきい値はすべて仮の初期値であり、shadow での観測を経てから調整する。
+ *
+ * public-get だけインメモリにしているのは Upstash の消費を抑えるため。
+ * 全リクエストの大半は公開 GET（App Router の自動 prefetch を含む）で、
+ * これを Upstash で数えると無料枠の月 500K コマンドをすぐ使い切る。
+ * 使い切ると全経路のレート制限が失われるため、守る優先度が最も高い
+ * 従量課金 API（server-action）とサインインに枠を回している。
+ * 公開 GET が守るのは back の負荷であり、近似の制限で足りる。
  */
 export const RATE_LIMIT_BUCKETS = {
-  "server-action": { limit: 20, windowMs: ONE_MINUTE_MS },
-  signin: { limit: 10, windowMs: ONE_MINUTE_MS },
-  "public-get": { limit: 60, windowMs: ONE_MINUTE_MS },
-} as const satisfies Record<RouteGroup, LimiterConfig>;
+  "server-action": { limit: 20, windowMs: ONE_MINUTE_MS, shared: true },
+  signin: { limit: 10, windowMs: ONE_MINUTE_MS, shared: true },
+  "public-get": { limit: 60, windowMs: ONE_MINUTE_MS, shared: false },
+} as const satisfies Record<RouteGroup, BucketConfig>;
 
 const AUTH_ROUTE_PREFIX = "/api/auth";
 
@@ -179,6 +195,14 @@ export function getDefaultLimiter(group: RouteGroup): Limiter {
   const cached = limiterCache.get(group);
   if (cached) return cached;
 
+  const { shared, ...config } = RATE_LIMIT_BUCKETS[group];
+
+  if (!shared) {
+    const memoryLimiter = createMemoryLimiter(config);
+    limiterCache.set(group, memoryLimiter);
+    return memoryLimiter;
+  }
+
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
 
@@ -187,17 +211,13 @@ export function getDefaultLimiter(group: RouteGroup): Limiter {
   // enforce にしても実質的な制限がかからない
   if (!url || !token) {
     console.error(
-      "[guard] UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN が未設定のため、" +
-        "アイソレート間で共有されないインメモリカウンタで動作します。" +
-        "本番では必ず設定してください。",
+      `[guard] UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN が未設定のため、` +
+        `${group} をアイソレート間で共有されないインメモリカウンタで数えます。` +
+        `本番では必ず設定してください。`,
     );
   }
 
-  const limiter = createLimiter({
-    url,
-    token,
-    ...RATE_LIMIT_BUCKETS[group],
-  });
+  const limiter = createLimiter({ url, token, ...config });
   limiterCache.set(group, limiter);
   return limiter;
 }

--- a/app/lib/guard/index.ts
+++ b/app/lib/guard/index.ts
@@ -29,8 +29,13 @@ export type GuardDecision = {
   limit?: number;
   remaining?: number;
   resetSec?: number;
-  /** ストア障害により fail-open した場合に true */
+  /** 判定そのものができず素通しした場合に true */
   unavailable?: boolean;
+  /**
+   * 共有ストアが使えず、インメモリの近似カウンタで数えた場合に true。
+   * 制限はかかっているが精度が落ちている状態を表す。
+   */
+  degraded?: boolean;
 };
 
 export type GuardReason =
@@ -65,10 +70,10 @@ const ONE_MINUTE_MS = 60_000;
 
 type BucketConfig = LimiterConfig & {
   /**
-   * true なら Upstash（アイソレート間で共有・正確）、false ならインメモリ
-   * （アイソレート単位・近似）でカウントする。
+   * shared   … Upstash で数える（アイソレート間で共有・正確）
+   * isolated … インメモリで数える（アイソレート単位・近似）
    */
-  shared: boolean;
+  store: "shared" | "isolated";
 };
 
 /**
@@ -76,17 +81,22 @@ type BucketConfig = LimiterConfig & {
  *
  * しきい値はすべて仮の初期値であり、shadow での観測を経てから調整する。
  *
- * public-get だけインメモリにしているのは Upstash の消費を抑えるため。
+ * public-get だけ isolated にしているのは Upstash の消費を抑えるため。
  * 全リクエストの大半は公開 GET（App Router の自動 prefetch を含む）で、
  * これを Upstash で数えると無料枠の月 500K コマンドをすぐ使い切る。
  * 使い切ると全経路のレート制限が失われるため、守る優先度が最も高い
  * 従量課金 API（server-action）とサインインに枠を回している。
- * 公開 GET が守るのは back の負荷であり、近似の制限で足りる。
+ *
+ * ただし isolated は「アイソレートごとに limit」なので、実効上限は
+ * アイソレート数に応じて緩む。しかも負荷が高いほど Vercel が
+ * スケールアウトしてアイソレートが増えるため、**制限が最も必要な瞬間ほど
+ * 効きが弱くなる**。公開 GET の防御は「無制限よりまし」の水準であり、
+ * back 側の防御が別途成立していることが前提になる。
  */
 export const RATE_LIMIT_BUCKETS = {
-  "server-action": { limit: 20, windowMs: ONE_MINUTE_MS, shared: true },
-  signin: { limit: 10, windowMs: ONE_MINUTE_MS, shared: true },
-  "public-get": { limit: 60, windowMs: ONE_MINUTE_MS, shared: false },
+  "server-action": { limit: 20, windowMs: ONE_MINUTE_MS, store: "shared" },
+  signin: { limit: 10, windowMs: ONE_MINUTE_MS, store: "shared" },
+  "public-get": { limit: 60, windowMs: ONE_MINUTE_MS, store: "isolated" },
 } as const satisfies Record<RouteGroup, BucketConfig>;
 
 const AUTH_ROUTE_PREFIX = "/api/auth";
@@ -195,9 +205,12 @@ export function getDefaultLimiter(group: RouteGroup): Limiter {
   const cached = limiterCache.get(group);
   if (cached) return cached;
 
-  const { shared, ...config } = RATE_LIMIT_BUCKETS[group];
+  const bucket = RATE_LIMIT_BUCKETS[group];
+  // フィールドを明示的に取り出す。rest 展開だと BucketConfig にフィールドが
+  // 増えたとき、構造的部分型のため気付かないまま limiter 側へ流れてしまう
+  const config = { limit: bucket.limit, windowMs: bucket.windowMs };
 
-  if (!shared) {
+  if (bucket.store === "isolated") {
     const memoryLimiter = createMemoryLimiter(config);
     limiterCache.set(group, memoryLimiter);
     return memoryLimiter;
@@ -266,7 +279,7 @@ async function evaluateGuard(
 
   // クローラーには公開ページの閲覧だけを許す
   const isCrawler =
-    botClass === "verified-crawler" || botClass === "seo-crawler";
+    botClass === "claimed-crawler" || botClass === "seo-crawler";
   if (isCrawler && group !== "public-get") {
     return { mode, action: "block", status: 403, reason: "crawler-scope" };
   }
@@ -303,6 +316,7 @@ async function evaluateGuard(
     limit: result.limit,
     remaining: result.remaining,
     resetSec: toResetSeconds(result.reset, now),
+    degraded: result.degraded,
   };
 
   if (!result.success) {

--- a/app/lib/guard/ip.ts
+++ b/app/lib/guard/ip.ts
@@ -31,7 +31,8 @@ function isIpLiteral(value: string): boolean {
  * x-forwarded-for は Vercel 以外（ローカルの next start・E2E）向けの
  * フォールバック。x-real-ip が付かない環境で全員が同じカウンタを共有して
  * サイト全体が 1 バケットに落ちるのを避けるために残している。
- * この経路は詐称可能なので、Vercel 以外へデプロイする場合は必ず見直すこと。
+ * ただしクライアントが自由に名乗れるヘッダーなので、Vercel 上では候補にすら
+ * 入れない。コメントで注意するのではなく、環境で構造的に閉じる。
  *
  * cf-connecting-ip は読まない。Cloudflare を経由していない構成では
  * このヘッダーを取り除く主体が経路上に存在せず、クライアントが名乗った値を
@@ -41,7 +42,9 @@ function isIpLiteral(value: string): boolean {
 export function getClientIp(headers: Headers): string {
   const candidates = [
     ipAddress(headers),
-    headers.get("x-forwarded-for")?.split(",")[0].trim(),
+    ...(process.env.VERCEL
+      ? []
+      : [headers.get("x-forwarded-for")?.split(",")[0].trim()]),
   ];
 
   for (const candidate of candidates) {

--- a/app/lib/guard/ratelimit.ts
+++ b/app/lib/guard/ratelimit.ts
@@ -9,6 +9,12 @@ export type LimiterResult = {
   remaining: number;
   /** カウンタが回復する時刻（Unix ミリ秒） */
   reset: number;
+  /**
+   * 共有ストアが使えず、インメモリのカウンタで数えた場合に true。
+   * アイソレート単位の近似になっているという意味であり、
+   * 制限がかかっていない（unavailable）とは区別する。
+   */
+  degraded?: boolean;
 };
 
 export type Limiter = {
@@ -16,7 +22,7 @@ export type Limiter = {
 };
 
 export type RateLimitResult = LimiterResult & {
-  /** ストア障害により fail-open した場合に true */
+  /** 判定そのものができず素通しした場合に true */
   unavailable: boolean;
 };
 
@@ -25,24 +31,33 @@ export type LimiterConfig = {
   windowMs: number;
 };
 
-/** インメモリのエントリ上限。超えたら期限切れのキーを掃除する */
+/** インメモリのエントリ上限。超えたら最終アクセスの古いものから落とす */
 const MAX_ENTRIES = 10_000;
 
-/** Upstash の応答を待つ上限。超えたら通す（可用性優先） */
+/** Upstash の応答を待つ上限。超えたらインメモリへ退避する */
 const UPSTASH_TIMEOUT_MS = 300;
+
+/**
+ * 退避時にしきい値を割る数。
+ *
+ * 退避先はアイソレートごとに独立して数えるため、同じしきい値のままだと
+ * 実効上限がアイソレート数倍に緩む。退避中はむしろ絞る。
+ */
+const FALLBACK_DIVISOR = 4;
+
+/** 退避の記録を出す間隔。障害中に毎リクエスト出力するとログ課金が膨らむ */
+const REPORT_INTERVAL_MS = 60_000;
 
 /**
  * プロセス内のスライディングログによるレート制限。
  *
- * Upstash が未設定のときのフォールバック。Edge のアイソレート間で状態を
- * 共有しないため、本番では使わないこと。
+ * Edge のアイソレート間で状態を共有しないため、実効上限はアイソレート数に
+ * 応じて緩む。負荷が高いほどスケールアウトしてアイソレートが増えるので、
+ * **制限が最も必要な瞬間ほど効きが弱くなる**点に注意する。
  */
 export function createMemoryLimiter({ limit, windowMs }: LimiterConfig): Limiter {
   const hits = new Map<string, number[]>();
-
-  /** ウィンドウ外に出たタイムスタンプを落とした履歴を返す */
-  const withinWindow = (key: string, threshold: number): number[] =>
-    (hits.get(key) ?? []).filter((timestamp) => timestamp > threshold);
+  let lastPrunedAt = 0;
 
   /** すべてのタイムスタンプが期限切れになったキーを取り除く */
   const pruneExpired = (threshold: number): void => {
@@ -53,10 +68,39 @@ export function createMemoryLimiter({ limit, windowMs }: LimiterConfig): Limiter
     }
   };
 
+  /**
+   * 上限に達した Map を縮める。
+   *
+   * 全走査は満杯時に毎リクエスト走ると重いため、ウィンドウごとに 1 回までに
+   * 抑える。それでも縮まらない場合は最終アクセスの古いものから落とす。
+   */
+  const evictIfFull = (now: number, threshold: number): void => {
+    if (hits.size < MAX_ENTRIES) return;
+
+    if (now - lastPrunedAt > windowMs) {
+      pruneExpired(threshold);
+      lastPrunedAt = now;
+    }
+
+    while (hits.size >= MAX_ENTRIES) {
+      const oldestKey = hits.keys().next().value;
+      if (oldestKey === undefined) break;
+      hits.delete(oldestKey);
+    }
+  };
+
   return {
     limit: (key, now = Date.now()) => {
       const threshold = now - windowMs;
-      const recent = withinWindow(key, threshold);
+      const recent = (hits.get(key) ?? []).filter(
+        (timestamp) => timestamp > threshold,
+      );
+
+      // Map#set は既存キーの挿入位置を変えないため、必ず delete してから
+      // set し直して「最終アクセス順」を保つ。これをしないと、上限到達時の
+      // 追い出しで「いま制限に掛かっているキー」から先に消えてしまい、
+      // 新規キーを流し込むだけでカウンタをリセットできる回避経路になる
+      hits.delete(key);
 
       if (recent.length >= limit) {
         hits.set(key, recent);
@@ -68,17 +112,7 @@ export function createMemoryLimiter({ limit, windowMs }: LimiterConfig): Limiter
         });
       }
 
-      if (hits.size >= MAX_ENTRIES) {
-        pruneExpired(threshold);
-        // 期限切れが 1 件も無い場合（新しいキーばかりを送り付けられた場合）
-        // pruneExpired だけでは縮まない。挿入順＝おおむね古い順に必ず落として
-        // 上限を守る。そうしないとアイソレートのメモリを攻撃者に食い潰される
-        while (hits.size >= MAX_ENTRIES) {
-          const oldestKey = hits.keys().next().value;
-          if (oldestKey === undefined) break;
-          hits.delete(oldestKey);
-        }
-      }
+      evictIfFull(now, threshold);
 
       recent.push(now);
       hits.set(key, recent);
@@ -99,29 +133,47 @@ export function createMemoryLimiter({ limit, windowMs }: LimiterConfig): Limiter
  * 素通しにはしない。Upstash の無料枠（月 500K コマンド）を使い切ると
  * 以降のリクエストが全部エラーになるため、素通しだと「月末になると
  * レート制限が消える」ことになり、守りたい従量課金 API が一番無防備になる。
- * アイソレート間で共有されない粗い制限でも、無制限よりははるかにましである。
+ *
+ * 退避先は wrapper の生存期間中ずっと使い回される。primary が復帰すれば
+ * そこで return するため退避先は読み書きされなくなるが、primary が
+ * 間欠的に失敗する状態では「primary の枠」と「退避先の枠」が並行して
+ * 消費されるため、その間だけ実効上限が緩む点に注意する。
  */
 export function withMemoryFallback(
   primary: Limiter,
   config: LimiterConfig,
 ): Limiter {
   const fallback = createMemoryLimiter(config);
-  // 障害中は毎リクエスト出力されてログが膨らむため、最初の 1 回だけ記録する
-  let reported = false;
+  let lastReportedAt = 0;
+  let degradedCount = 0;
 
   return {
-    limit: async (key, now) => {
+    limit: async (key, now = Date.now()) => {
       try {
-        return await primary.limit(key, now);
+        const result = await primary.limit(key, now);
+
+        if (degradedCount > 0) {
+          console.info(
+            `[guard] ストアが復旧しました（退避中に判定した件数: ${degradedCount}）`,
+          );
+          degradedCount = 0;
+          lastReportedAt = 0;
+        }
+        return result;
       } catch (error) {
-        if (!reported) {
-          reported = true;
+        degradedCount += 1;
+
+        // 再発を検知できるよう、一定間隔ごとに出し直す
+        if (now - lastReportedAt > REPORT_INTERVAL_MS) {
+          lastReportedAt = now;
           console.error(
             "[guard] ストアが使えないためインメモリのカウンタへ退避します:",
             error instanceof Error ? error.message : "unknown error",
           );
         }
-        return fallback.limit(key, now);
+
+        const result = await fallback.limit(key, now);
+        return { ...result, degraded: true };
       }
     },
   };
@@ -152,8 +204,7 @@ export function createLimiter({
     limiter: Ratelimit.slidingWindow(limit, `${windowSeconds} s`),
     analytics: false,
     // Upstash が「応答しない」場合は例外が出ないため try/catch では拾えず、
-    // middleware がハングして全リクエストのレイテンシに直結する。
-    // タイムアウト時は success: true が返り、意図どおりの fail-open になる
+    // middleware がハングして全リクエストのレイテンシに直結する
     timeout: UPSTASH_TIMEOUT_MS,
     // キーは呼び出し側で "guard:" から組み立てているため、ここでは付けない
     // （付けると guard:guard:... と二重になる）
@@ -163,6 +214,13 @@ export function createLimiter({
   const upstashLimiter: Limiter = {
     limit: async (key) => {
       const result = await ratelimit.limit(key);
+
+      // ライブラリはタイムアウト時に reject せず success: true で resolve する。
+      // ここで例外にしないと退避処理に落ちず、レート制限が無言で全面解除される
+      if (result.reason === "timeout") {
+        throw new Error("upstash timeout");
+      }
+
       return {
         success: result.success,
         limit: result.limit,
@@ -172,13 +230,17 @@ export function createLimiter({
     },
   };
 
-  return withMemoryFallback(upstashLimiter, { limit, windowMs });
+  return withMemoryFallback(upstashLimiter, {
+    limit: Math.max(1, Math.ceil(limit / FALLBACK_DIVISOR)),
+    windowMs,
+  });
 }
 
 /**
- * レート制限を判定する。ストアが落ちていてもリクエストは通す（fail-open）。
+ * レート制限を判定する。
  *
- * 可用性を優先し、Upstash を単一障害点にしない。
+ * 通常の障害は createLimiter 内の退避処理で吸収されるため、ここに来るのは
+ * 退避先まで失敗した場合だけ。最後の砦としてリクエストを通す。
  */
 export async function checkLimit(
   limiter: Limiter,

--- a/app/lib/guard/ratelimit.ts
+++ b/app/lib/guard/ratelimit.ts
@@ -94,6 +94,40 @@ export function createMemoryLimiter({ limit, windowMs }: LimiterConfig): Limiter
 }
 
 /**
+ * ストアが使えないときにインメモリのカウンタへ退避する limiter を作る。
+ *
+ * 素通しにはしない。Upstash の無料枠（月 500K コマンド）を使い切ると
+ * 以降のリクエストが全部エラーになるため、素通しだと「月末になると
+ * レート制限が消える」ことになり、守りたい従量課金 API が一番無防備になる。
+ * アイソレート間で共有されない粗い制限でも、無制限よりははるかにましである。
+ */
+export function withMemoryFallback(
+  primary: Limiter,
+  config: LimiterConfig,
+): Limiter {
+  const fallback = createMemoryLimiter(config);
+  // 障害中は毎リクエスト出力されてログが膨らむため、最初の 1 回だけ記録する
+  let reported = false;
+
+  return {
+    limit: async (key, now) => {
+      try {
+        return await primary.limit(key, now);
+      } catch (error) {
+        if (!reported) {
+          reported = true;
+          console.error(
+            "[guard] ストアが使えないためインメモリのカウンタへ退避します:",
+            error instanceof Error ? error.message : "unknown error",
+          );
+        }
+        return fallback.limit(key, now);
+      }
+    },
+  };
+}
+
+/**
  * Upstash が設定されていれば Upstash 版を、未設定ならインメモリ版を返す。
  *
  * analytics は無効にしている。無料枠のコマンド数を節約でき、Edge で
@@ -126,7 +160,7 @@ export function createLimiter({
     prefix: "",
   });
 
-  return {
+  const upstashLimiter: Limiter = {
     limit: async (key) => {
       const result = await ratelimit.limit(key);
       return {
@@ -137,6 +171,8 @@ export function createLimiter({
       };
     },
   };
+
+  return withMemoryFallback(upstashLimiter, { limit, windowMs });
 }
 
 /**

--- a/middleware.ts
+++ b/middleware.ts
@@ -67,6 +67,9 @@ function applyDebugHeaders(
   if (decision.remaining !== undefined) {
     response.headers.set("x-guard-remaining", String(decision.remaining));
   }
+  if (decision.degraded) {
+    response.headers.set("x-guard-degraded", "1");
+  }
 }
 
 export default auth(async (req) => {

--- a/tests/components/guard/bot.spec.ts
+++ b/tests/components/guard/bot.spec.ts
@@ -7,7 +7,7 @@ const HEADLESS_CHROME_UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/131.0.0.0 Safari/537.36";
 
 test.describe("classifyBot", () => {
-  test("should allow me to classify Googlebot as a verified crawler", () => {
+  test("should allow me to classify Googlebot as a claimed crawler", () => {
     // Arrange
     const ua =
       "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
@@ -16,10 +16,10 @@ test.describe("classifyBot", () => {
     const result = classifyBot(ua);
 
     // Assert
-    expect(result).toBe("verified-crawler");
+    expect(result).toBe("claimed-crawler");
   });
 
-  test("should allow me to classify a verified crawler regardless of letter case", () => {
+  test("should allow me to classify a claimed crawler regardless of letter case", () => {
     // Arrange
     const ua = "Mozilla/5.0 (compatible; BINGBOT/2.0; +http://www.bing.com/bingbot.htm)";
 
@@ -27,10 +27,10 @@ test.describe("classifyBot", () => {
     const result = classifyBot(ua);
 
     // Assert
-    expect(result).toBe("verified-crawler");
+    expect(result).toBe("claimed-crawler");
   });
 
-  test("should allow me to classify facebookexternalhit as a verified crawler", () => {
+  test("should allow me to classify facebookexternalhit as a claimed crawler", () => {
     // Arrange
     const ua = "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)";
 
@@ -38,7 +38,7 @@ test.describe("classifyBot", () => {
     const result = classifyBot(ua);
 
     // Assert
-    expect(result).toBe("verified-crawler");
+    expect(result).toBe("claimed-crawler");
   });
 
   test("should allow me to classify AhrefsBot as an seo crawler", () => {
@@ -117,6 +117,19 @@ test.describe("classifyBot", () => {
 
     // Assert
     expect(result).toBe("unknown");
+  });
+
+  test("should not allow me to evade the malicious check by claiming to be a crawler", () => {
+    // Arrange
+    // 悪性判定をクローラーの名乗りより先に行わないと、この UA が
+    // claimed-crawler になって 403 を回避できてしまう
+    const ua = "curl/8.4.0 Googlebot";
+
+    // Act
+    const result = classifyBot(ua);
+
+    // Assert
+    expect(result).toBe("malicious");
   });
 
   test("should allow me to classify an empty user agent as unknown", () => {

--- a/tests/components/guard/ratelimit.spec.ts
+++ b/tests/components/guard/ratelimit.spec.ts
@@ -147,6 +147,53 @@ test.describe("withMemoryFallback", () => {
     expect([first.success, second.success]).toEqual([true, false]);
   });
 
+  test("should allow me to see that the counter degraded to the in-memory store", async () => {
+    // Arrange
+    const broken: Limiter = {
+      limit: () => Promise.reject(new Error("unreachable")),
+    };
+    const limiter = withMemoryFallback(broken, { limit: 5, windowMs: WINDOW_MS });
+
+    // Act
+    const result = await limiter.limit("guard:signin:ip:198.51.100.20", NOW);
+
+    // Assert
+    // 「制限がかかっていない」ではなく「精度が落ちている」ことを区別できる
+    expect({ success: result.success, degraded: result.degraded }).toEqual({
+      success: true,
+      degraded: true,
+    });
+  });
+
+  test("should allow me to go back to the primary store once it recovers", async () => {
+    // Arrange
+    let failing = true;
+    const flaky: Limiter = {
+      limit: (key, now) => {
+        if (failing) return Promise.reject(new Error("temporarily down"));
+        return Promise.resolve({
+          success: true,
+          limit: 99,
+          remaining: 98,
+          reset: (now ?? NOW) + WINDOW_MS,
+        });
+      },
+    };
+    const limiter = withMemoryFallback(flaky, { limit: 1, windowMs: WINDOW_MS });
+    const key = "guard:server-action:ip:198.51.100.20";
+    await limiter.limit(key, NOW);
+
+    // Act
+    failing = false;
+    const recovered = await limiter.limit(key, NOW);
+
+    // Assert
+    expect({ limit: recovered.limit, degraded: recovered.degraded }).toEqual({
+      limit: 99,
+      degraded: undefined,
+    });
+  });
+
   test("should allow me to keep the fallback counters separate per key", async () => {
     // Arrange
     const broken: Limiter = {
@@ -160,6 +207,39 @@ test.describe("withMemoryFallback", () => {
 
     // Assert
     expect(other.success).toBe(true);
+  });
+});
+
+test.describe("createMemoryLimiter の追い出し", () => {
+  test("should not allow me to reset an active counter by flooding new keys", async () => {
+    // Arrange
+    // Map#set は既存キーの挿入位置を変えないため、delete してから set し直さないと
+    // 「最初に観測したキー」から追い出される。アクセスされ続けているキーほど
+    // 古い位置に残るので、連打中の相手が真っ先にリセットされてしまう。
+    //
+    // なお、これを直しても「自分のキーを触らずに大量の新規キーを流し込んで
+    // 自分を追い出す」攻撃は防げない。有限のメモリで数える以上は避けられず、
+    // public-get を「無制限よりまし」の層と位置づけている理由でもある。
+    const limit = 100;
+    const limiter = createMemoryLimiter({ limit, windowMs: WINDOW_MS });
+    const activeKey = "guard:public-get:ip:198.51.100.20";
+    let touches = 0;
+
+    // Act
+    // 上限（10,000）を超える新規キーを送り込みつつ、対象キーも触り続ける
+    for (let i = 0; i < 10_050; i += 1) {
+      await limiter.limit(`guard:public-get:ip:10.0.${i >> 8}.${i & 255}`, NOW);
+      if (i % 2000 === 0) {
+        await limiter.limit(activeKey, NOW);
+        touches += 1;
+      }
+    }
+    const result = await limiter.limit(activeKey, NOW);
+    touches += 1;
+
+    // Assert
+    // 追い出されていなければ、それまでのアクセス回数がそのまま残っている
+    expect(result.remaining).toBe(limit - touches);
   });
 });
 

--- a/tests/components/guard/ratelimit.spec.ts
+++ b/tests/components/guard/ratelimit.spec.ts
@@ -3,6 +3,8 @@ import {
   createMemoryLimiter,
   createLimiter,
   checkLimit,
+  withMemoryFallback,
+  type Limiter,
 } from "@/app/lib/guard/ratelimit";
 
 const NOW = 1_700_000_000_000;
@@ -105,6 +107,59 @@ test.describe("createLimiter", () => {
 
     // Assert
     expect([first.success, second.success]).toEqual([true, false]);
+  });
+});
+
+test.describe("withMemoryFallback", () => {
+  test("should allow me to use the primary store while it is healthy", async () => {
+    // Arrange
+    const primary = createMemoryLimiter({ limit: 5, windowMs: WINDOW_MS });
+    const limiter = withMemoryFallback(primary, { limit: 1, windowMs: WINDOW_MS });
+
+    // Act
+    const result = await limiter.limit("guard:signin:ip:198.51.100.20", NOW);
+
+    // Assert
+    expect({ limit: result.limit, remaining: result.remaining }).toEqual({
+      limit: 5,
+      remaining: 4,
+    });
+  });
+
+  test("should not allow me to escape the rate limit when the store is exhausted", async () => {
+    // Arrange
+    // Upstash の無料枠を使い切ると以降は全部エラーになる。素通しにすると
+    // 月末にレート制限が消えてしまうため、粗くても数え続ける
+    const exhausted: Limiter = {
+      limit: () => Promise.reject(new Error("max monthly commands exceeded")),
+    };
+    const limiter = withMemoryFallback(exhausted, {
+      limit: 1,
+      windowMs: WINDOW_MS,
+    });
+    const key = "guard:server-action:ip:198.51.100.20";
+
+    // Act
+    const first = await limiter.limit(key, NOW);
+    const second = await limiter.limit(key, NOW);
+
+    // Assert
+    expect([first.success, second.success]).toEqual([true, false]);
+  });
+
+  test("should allow me to keep the fallback counters separate per key", async () => {
+    // Arrange
+    const broken: Limiter = {
+      limit: () => Promise.reject(new Error("unreachable")),
+    };
+    const limiter = withMemoryFallback(broken, { limit: 1, windowMs: WINDOW_MS });
+    await limiter.limit("guard:server-action:ip:198.51.100.20", NOW);
+
+    // Act
+    const other = await limiter.limit("guard:server-action:ip:203.0.113.10", NOW);
+
+    // Assert
+    expect(other.success).toBe(true);
   });
 });
 

--- a/tests/components/guard/runGuard.spec.ts
+++ b/tests/components/guard/runGuard.spec.ts
@@ -318,9 +318,23 @@ test.describe("RATE_LIMIT_BUCKETS", () => {
 
     // Assert
     expect(buckets).toEqual({
-      "server-action": { limit: 20, windowMs: 60_000 },
-      signin: { limit: 10, windowMs: 60_000 },
-      "public-get": { limit: 60, windowMs: 60_000 },
+      "server-action": { limit: 20, windowMs: 60_000, shared: true },
+      signin: { limit: 10, windowMs: 60_000, shared: true },
+      "public-get": { limit: 60, windowMs: 60_000, shared: false },
     });
+  });
+
+  test("should allow me to spend the shared store only on the buckets worth protecting", () => {
+    // Arrange
+    // 全リクエストの大半を占める公開 GET を Upstash で数えると
+    // 無料枠（月 500K コマンド）を使い切り、全経路の制限が失われる
+
+    // Act
+    const sharedGroups = Object.entries(RATE_LIMIT_BUCKETS)
+      .filter(([, bucket]) => bucket.shared)
+      .map(([group]) => group);
+
+    // Assert
+    expect(sharedGroups.sort()).toEqual(["server-action", "signin"]);
   });
 });

--- a/tests/components/guard/runGuard.spec.ts
+++ b/tests/components/guard/runGuard.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/experimental-ct-react";
-import { runGuard, RATE_LIMIT_BUCKETS } from "@/app/lib/guard";
+import {
+  runGuard,
+  RATE_LIMIT_BUCKETS,
+  getDefaultLimiter,
+} from "@/app/lib/guard";
 import { createMemoryLimiter, type Limiter } from "@/app/lib/guard/ratelimit";
 
 const NOW = 1_700_000_000_000;
@@ -87,7 +91,7 @@ test.describe("runGuard", () => {
     }).toEqual({ action: "block", status: 403, reason: "bot-ua" });
   });
 
-  test("should allow me to crawl a public page as a verified crawler", async () => {
+  test("should allow me to crawl a public page as a claimed crawler", async () => {
     // Arrange
     const request = publicGet(GOOGLEBOT_UA);
 
@@ -103,7 +107,7 @@ test.describe("runGuard", () => {
     expect(decision.action).toBe("allow");
   });
 
-  test("should not allow me to invoke a server action as a verified crawler", async () => {
+  test("should not allow me to invoke a server action as a claimed crawler", async () => {
     // Arrange
     const request = serverAction(GOOGLEBOT_UA);
 
@@ -318,9 +322,9 @@ test.describe("RATE_LIMIT_BUCKETS", () => {
 
     // Assert
     expect(buckets).toEqual({
-      "server-action": { limit: 20, windowMs: 60_000, shared: true },
-      signin: { limit: 10, windowMs: 60_000, shared: true },
-      "public-get": { limit: 60, windowMs: 60_000, shared: false },
+      "server-action": { limit: 20, windowMs: 60_000, store: "shared" },
+      signin: { limit: 10, windowMs: 60_000, store: "shared" },
+      "public-get": { limit: 60, windowMs: 60_000, store: "isolated" },
     });
   });
 
@@ -331,10 +335,38 @@ test.describe("RATE_LIMIT_BUCKETS", () => {
 
     // Act
     const sharedGroups = Object.entries(RATE_LIMIT_BUCKETS)
-      .filter(([, bucket]) => bucket.shared)
+      .filter(([, bucket]) => bucket.store === "shared")
       .map(([group]) => group);
 
     // Assert
     expect(sharedGroups.sort()).toEqual(["server-action", "signin"]);
+  });
+});
+
+test.describe("getDefaultLimiter", () => {
+  test("should allow me to reuse the same limiter for a group", async () => {
+    // Arrange & Act
+    const first = getDefaultLimiter("public-get");
+    const second = getDefaultLimiter("public-get");
+
+    // Assert
+    expect(first).toBe(second);
+  });
+
+  test("should allow me to count an isolated bucket without reaching the shared store", async () => {
+    // Arrange
+    // public-get は Upstash の設定有無に関わらずインメモリで数える。
+    // ネットワークへ出ないため、この呼び出しは即座に完了する
+    const limiter = getDefaultLimiter("public-get");
+    const key = `guard:public-get:ip:198.51.100.${Math.floor(Math.random() * 250)}`;
+
+    // Act
+    const result = await limiter.limit(key, Date.now());
+
+    // Assert
+    expect({ limit: result.limit, success: result.success }).toEqual({
+      limit: RATE_LIMIT_BUCKETS["public-get"].limit,
+      success: true,
+    });
   });
 });


### PR DESCRIPTION
関連 issue: #95（shadow 観測と enforce 有効化が残るため、この PR ではクローズしない）

## 概要

Upstash を **Free ティア（月 500K コマンド）から始め、使用量に応じて Pay as You Go へ移行する**方針にしたため、無料枠に収まるようカウント先をバケットごとに分けます。

500K コマンド/月は持続 **約 11.6 req/分**に相当します。ガード対象 1 リクエストにつき Upstash コマンドを約 1 件消費するため、全リクエストを Upstash で数えると早期に使い切ります。App Router は表示領域内のリンクを自動 prefetch するので、実リクエスト数はページビュー数を大きく上回ります。

### バケットごとのカウント先

| バケット | カウント先 | 理由 |
|---|---|---|
| `server-action` | Upstash（共有・正確） | 従量課金 API（PaizaIO / OpenAI）を守る本命 |
| `signin` | Upstash（共有・正確） | 攻撃対象。正確さが要る |
| `public-get` | インメモリ（アイソレート単位・近似） | 件数が最も多い。守る対象は back の負荷であり近似で足りる |

全リクエストの大半を占める公開 GET を外すことで、**Upstash の消費は概ね POST の件数まで下がります**。

### ストア不通時に素通ししない

`withMemoryFallback` を追加し、ストアがエラーを返したらインメモリのカウンタへ退避します。

```
無料枠を使い切る → Upstash がエラー → 素通し（従来）
                                      ↓
                        レート制限が月末まで完全に消える
```

これでは**守りたい従量課金 API が最も無防備になる**時期と、枠を使い切る時期（＝トラフィックが多い月末）が一致してしまいます。アイソレート間で共有されない粗い制限でも、無制限よりはるかにましなので退避させます。

障害中に毎リクエスト出力されてログが膨らまないよう、退避の記録は最初の 1 回だけ出します。

## 確認方法

1. `pnpm test:components` … CT が通ることを確認（guard は 77 テスト）
2. `pnpm test:e2e` … E2E が通ることを確認
3. `pnpm lint` … 警告・エラーがないことを確認

挙動の確認:

```bash
# UPSTASH_* を未設定のまま起動すると、server-action / signin について
# 「インメモリで数える」旨のエラーログが出る（public-get では出ない）
pnpm build && GUARD_MODE=shadow pnpm start -p 4020
```

## 影響範囲

- `GUARD_MODE` 未設定時の挙動変更はありません
- `RATE_LIMIT_BUCKETS` に `shared` フィールドが増えます（型は `BucketConfig`）
- `getDefaultLimiter` が `shared: false` のバケットでは Upstash を参照しなくなります
- `createLimiter` の戻り値が `withMemoryFallback` でラップされます。`checkLimit` の fail-open は最後の砦として残ります

### 検証結果

| 項目 | 結果 |
|---|---|
| CT（全ブラウザ） | 630 passed / 3 skipped（skip は既存の `ResponsiveNav.spec.tsx:29`） |
| E2E（全ブラウザ + guard-enforce） | 506 passed |
| `tsc --noEmit` / `pnpm lint` | エラー・警告なし |

## チェックリスト

- [x] Lint のチェックをパスした
- [x] ユニットテスト（コンポーネントテスト）を追加してパスした
- [x] E2E テストをパスした

## コメント

### プラン移行の判断基準

- shadow 観測中に月間 **250K コマンド（無料枠の 50%）**を超えたら PAYG へ
- PAYG は **$0.20 / 100K コマンド**。1M/月でも $2 と安価で、コスト自体は問題になりません
- 移行と同時に **budget を設定**します（Usage タブ、または `PATCH /redis/update-budget/{id}`）。到達時はスロットルされ、設定額を超える請求は発生しません

### budget 設定時の注意

budget に達すると Upstash はスロットルされるため、**この PR の退避処理が働く前提**で金額を決めてください。退避がなければ「コスト上限が防御を落とすスイッチ」として機能してしまい、攻撃者が安いリクエストで枠を使い切らせるだけで本命の従量課金 API を無防備にできます。

### 残る制約

`public-get` の制限はアイソレート単位の近似になります。Vercel の Edge はリクエストごとに別アイソレートになり得るため、**実効的な上限は 60 req/分より緩くなります**。公開 GET については「無制限よりまし」程度の位置づけとして、shadow 観測で実際の効き具合を確認してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)