### PR TITLE
fix: public-get のしきい値を実測に基づき 300 req/分へ引き上げる

### DIFF
--- a/app/lib/guard/index.ts
+++ b/app/lib/guard/index.ts
@@ -92,11 +92,22 @@ type BucketConfig = LimiterConfig & {
  * スケールアウトしてアイソレートが増えるため、**制限が最も必要な瞬間ほど
  * 効きが弱くなる**。公開 GET の防御は「無制限よりまし」の水準であり、
  * back 側の防御が別途成立していることが前提になる。
+ *
+ * public-get の 300 は実測に基づく。App Router は表示領域内のリンクを
+ * 自動 prefetch するため、1 ページ閲覧で `?_rsc=` 付きの GET が数件飛び、
+ * 合計 5 リクエスト前後（トップページは 7）を消費する。当初の 60 では
+ * 12 ページ/分（5 秒に 1 ページ）で上限に達し、通常の回遊で 429 になった。
+ * 300 は 1 秒 1 ページ相当の閲覧を許容する値で、人間の操作としては
+ * ほぼ上限にあたる。これを超えるのはスクリプトである。
+ *
+ * prefetch の件数はコンテンツ件数に比例しない（算額 4 件のページと 0 件の
+ * ページが同じリクエスト数だった）。カードが <Link> を持たず、地図の
+ * マーカーもクライアント側描画のため、ヘッダー/フッターのナビ分で固定される。
  */
 export const RATE_LIMIT_BUCKETS = {
   "server-action": { limit: 20, windowMs: ONE_MINUTE_MS, store: "shared" },
   signin: { limit: 10, windowMs: ONE_MINUTE_MS, store: "shared" },
-  "public-get": { limit: 60, windowMs: ONE_MINUTE_MS, store: "isolated" },
+  "public-get": { limit: 300, windowMs: ONE_MINUTE_MS, store: "isolated" },
 } as const satisfies Record<RouteGroup, BucketConfig>;
 
 const AUTH_ROUTE_PREFIX = "/api/auth";

--- a/tests/components/guard/runGuard.spec.ts
+++ b/tests/components/guard/runGuard.spec.ts
@@ -324,7 +324,9 @@ test.describe("RATE_LIMIT_BUCKETS", () => {
     expect(buckets).toEqual({
       "server-action": { limit: 20, windowMs: 60_000, store: "shared" },
       signin: { limit: 10, windowMs: 60_000, store: "shared" },
-      "public-get": { limit: 60, windowMs: 60_000, store: "isolated" },
+      // 1 ページ閲覧で prefetch 込み 5 リクエスト前後を消費するため、
+      // 60 では 12 ページ/分で上限に達し通常の回遊で 429 になる（実測）
+      "public-get": { limit: 300, windowMs: 60_000, store: "isolated" },
     });
   });
 

--- a/tests/e2e/guard/enforce.spec.ts
+++ b/tests/e2e/guard/enforce.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@/tests/e2e/fixtures";
+import { RATE_LIMIT_BUCKETS } from "@/app/lib/guard";
 
 /**
  * ガードの遮断挙動を検証する。GUARD_MODE=enforce のサーバー（ポート 4021）に対して実行する。
@@ -6,7 +7,8 @@ import { test, expect } from "@/tests/e2e/fixtures";
  * インメモリのカウンタはプロセス内で共有されるため、テストごとに
  * x-forwarded-for で別 IP を名乗ってカウンタを分離する。
  */
-const PUBLIC_GET_LIMIT = 60;
+/** しきい値を実装から取得する。ハードコードすると変更時に静かにずれる */
+const PUBLIC_GET_LIMIT = RATE_LIMIT_BUCKETS["public-get"].limit;
 
 test.describe("Middleware guard (enforce)", () => {
   test("should not allow me to reach the app with a malicious user agent", async ({

--- a/tests/e2e/guard/shadow.spec.ts
+++ b/tests/e2e/guard/shadow.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@/tests/e2e/fixtures";
 import type { TestInfo } from "@playwright/test";
+import { RATE_LIMIT_BUCKETS } from "@/app/lib/guard";
 
 /**
  * 通常の E2E サーバー（ポート 4020）は GUARD_MODE=shadow で動く。
@@ -65,7 +66,9 @@ test.describe("Middleware guard (shadow)", () => {
       headers: debugHeaders(testInfo, 11),
     });
 
-    expect(Number(response.headers()["x-guard-remaining"])).toBe(59);
+    expect(Number(response.headers()["x-guard-remaining"])).toBe(
+      RATE_LIMIT_BUCKETS["public-get"].limit - 1,
+    );
   });
 
   test("should allow me to keep browsing with a malicious user agent while only observing", async ({
@@ -88,7 +91,9 @@ test.describe("Middleware guard (shadow)", () => {
     const headers = debugHeaders(testInfo, 14);
 
     const responses = await Promise.all(
-      Array.from({ length: 65 }, () => request.get("/", { headers })),
+      Array.from({ length: RATE_LIMIT_BUCKETS["public-get"].limit + 5 }, () =>
+        request.get("/", { headers }),
+      ),
     );
     const blocked = responses.filter((response) => response.status() !== 200);
 


### PR DESCRIPTION
関連 issue: #95（shadow 観測と enforce 有効化が残るため、この PR ではクローズしない）

## 概要

`public-get` のしきい値 60 req/分は**実測の結果、明確に低すぎる**と判明したため 300 req/分へ引き上げます。

App Router は表示領域内のリンクを自動 prefetch し、`?_rsc=` 付きの GET が middleware を通ります。この分が `public-get` バケットを消費するため、1 ページ閲覧あたりのリクエスト数がページビュー数を上回ります。

### 実測結果

prefetch を無効化していないビルド（`APP_ENV=test` を付けずに `next build`）を起動し、Playwright で `?_rsc=` リクエストを数えました。ローカルの back を起動した状態で計測しています。

| ページ | 内部リンク | prefetch(`_rsc`) | ガードが数える合計 |
|---|---|---|---|
| `/`（トップ） | 12 | 6 | **7** |
| `/shrines`（地図） | 8 | 3 | 4 |
| `/shrines/3/sangakus`（算額 4 件） | 8 | 4 | 5 |
| `/shrines/1/sangakus`（算額 0 件） | 8 | 4 | 5 |

```
1 ページ閲覧 ≒ 5 リクエスト（トップページは 7）
60 ÷ 5 ≒ 12 ページ/分 で上限到達
```

**5 秒に 1 ページの回遊で 429 になります。** ごく普通の操作であり、この値のまま enforce にすると正規ユーザーを締め出していました。

### prefetch はコンテンツ件数に比例しない

算額 4 件のページと 0 件のページが**まったく同じ 5 リクエスト**でした（ページが正しく描画されていることは HTML で確認済み）。算額カードが `<Link>` を持たず、地図のマーカーもクライアント側描画のためです。

つまり prefetch の負荷はヘッダー/フッターのナビゲーション分（3〜6 件）でほぼ固定で、**データが増えても悪化しません**。当初「一覧ページはカード 1 枚ごとにリンクがあるので数倍になる」と見積もっていましたが、これは誤りでした。

倍率が一定と分かったため、しきい値は逆算できます。

| 許容したい閲覧速度 | 必要なしきい値 |
|---|---|
| 12 ページ/分 | 60（当初値） |
| 30 ページ/分 | 150 |
| 60 ページ/分（1 秒 1 ページ相当） | **300** |

**300 を採用します。** 人間の操作としては 1 秒 1 ページが上限に近く、これを超えるのはスクリプトです。スクレイパーは通常さらに高速なため、300 でも抑止として機能します。

## 確認方法

1. `pnpm test:components` … CT が通ることを確認（guard は 83 テスト）
2. `pnpm test:e2e` … E2E が通ることを確認
3. `pnpm lint`

実測を再現する場合:

```bash
# prefetch を有効にするため APP_ENV=test を付けずにビルドする
E2E_MOCK_MAPS=true pnpm run build
GUARD_MODE=off pnpm run start -p 4030
# Playwright でページを開き、?_rsc= 付きリクエストを数える
```

## 影響範囲

- `GUARD_MODE` 未設定時の挙動変更はありません
- 変更は `RATE_LIMIT_BUCKETS["public-get"].limit` の 1 値のみ。ロジックは変えていません
- E2E がしきい値を `PUBLIC_GET_LIMIT = 60` とハードコードしていた箇所を、実装から取得する形に変えました。今後しきい値を変えてもテストが静かにずれません
- バースト検証のリクエスト数が 65 → 305 に増えますが、実行時間は 2.2 分で従来と変わりませんでした

### 検証結果

| 項目 | 結果 |
|---|---|
| CT（全ブラウザ） | 648 passed / 3 skipped（skip は既存の `ResponsiveNav.spec.tsx:29`） |
| E2E（全ブラウザ + guard-enforce） | 506 passed |
| `tsc --noEmit` / `pnpm lint` | エラー・警告なし |

## チェックリスト

- [x] Lint のチェックをパスした
- [x] ユニットテスト（コンポーネントテスト）をパスした
- [x] E2E テストをパスした

## コメント

### 残る不確実性

- 計測は**未認証**で実施しました。ログイン時はヘッダーのメニュー項目が増えるため、数件多くなる見込みです
- `?_rsc=` を別バケットに分けて本体ロードだけ厳しく保つ案も検討しましたが、コンテンツ比例しないと分かったため単純な引き上げで足りると判断しました
- 300 も依然として仮の値です。shadow 観測で実トラフィックを確認したうえで最終決定してください

### shadow 観測の手段について（別途要検討）

公式ドキュメントで確認したところ、**Hobby プランでは当初計画していた「1〜2 週間の shadow 観測」が成立しません**。

| プラン | Runtime Logs 保持 |
|---|---|
| **Hobby** | **1 時間** |
| Pro | 1 日 |
| Pro + Observability Plus | 30 日 |

さらに Log Drains は **Pro 以上でのみ利用可能**です（$0.50/GB）。

プラン変更なしで観測する案を issue #95 に記録しています（Upstash Ratelimit の `analytics` を観測期間だけ有効化する / `public-get` を一時的に `store: "shared"` にする / would-block を Upstash のカウンタに書く）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)