### PR TITLE
fix: 解答作成・取得エンドポイントを saved_sangakus 配下に追従させる

### DIFF
--- a/app/lib/actions/answer.ts
+++ b/app/lib/actions/answer.ts
@@ -28,12 +28,14 @@ export const createAnswer = async (sangaku_id: string, source: string) => {
   }
 
   const params = {
-    source,
+    answer: {
+      source,
+    },
   };
 
   try {
     const res = await serverFetch(
-      `${apiUrl}/api/v1/user/sangakus/${encodeURIComponent(sangaku_id)}/answers`,
+      `${apiUrl}/api/v1/user/saved_sangakus/${encodeURIComponent(sangaku_id)}/answer`,
       {
         method: "POST",
         token: session?.accessToken,
@@ -45,7 +47,7 @@ export const createAnswer = async (sangaku_id: string, source: string) => {
       case 200:
         await setFlash({ type: "success", message: "算額を解答しました" });
         revalidatePath("/saved_sangakus");
-        redirect(`/saved_sangakus/${sangaku_id}/answer`);
+        redirect(`/saved_sangakus/${sangaku_id}/answer`); // 必ず throw するため case 401 へは落ちない
       case 401:
         await setFlash({
           type: "error",

--- a/app/lib/data/answer.ts
+++ b/app/lib/data/answer.ts
@@ -5,14 +5,22 @@ import type { Answer } from "../definitions";
 import { isRedirectError } from "next/dist/client/components/redirect-error";
 import { serverFetch } from "@/app/lib/server-fetch";
 import { apiUrl } from "@/app/lib/config";
+import { isValidId } from "@/app/lib/validate-id";
 
 export const fetchUserAnswer = async (id: string) => {
+  if (!isValidId(id)) {
+    return null;
+  }
+
   const session = await auth();
 
   try {
-    const res = await serverFetch(`${apiUrl}/api/v1/user/answers/${id}`, {
-      token: session?.accessToken,
-    });
+    const res = await serverFetch(
+      `${apiUrl}/api/v1/user/answers/${encodeURIComponent(id)}`,
+      {
+        token: session?.accessToken,
+      },
+    );
 
     switch (res.status) {
       case 200:
@@ -36,11 +44,15 @@ export const fetchUserAnswer = async (id: string) => {
 };
 
 export const fetchUserAnswerWithSangakuId = async (sangakuId: string) => {
+  if (!isValidId(sangakuId)) {
+    return null;
+  }
+
   const session = await auth();
 
   try {
     const res = await serverFetch(
-      `${apiUrl}/api/v1/user/saved_sangakus/${sangakuId}/answer`,
+      `${apiUrl}/api/v1/user/saved_sangakus/${encodeURIComponent(sangakuId)}/answer`,
       { token: session?.accessToken },
     );
 

--- a/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
+++ b/tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts
@@ -68,7 +68,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
               },
             );
           }),
-          http.post(`${apiUrl}/api/v1/user/sangakus/1/answers`, () => {
+          http.post(`${apiUrl}/api/v1/user/saved_sangakus/1/answer`, () => {
             return HttpResponse.json(
               {
                 data: {
@@ -268,7 +268,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
       msw,
     }) => {
       msw.use(
-        http.post(`${apiUrl}/api/v1/user/sangakus/1/answers`, () => {
+        http.post(`${apiUrl}/api/v1/user/saved_sangakus/1/answer`, () => {
           return HttpResponse.json(
             {
               message: "Bad Request",
@@ -304,7 +304,7 @@ test.describe("/saved_sangakus/[id]/answer/create", () => {
       msw,
     }) => {
       msw.use(
-        http.post(`${apiUrl}/api/v1/user/sangakus/1/answers`, () => {
+        http.post(`${apiUrl}/api/v1/user/saved_sangakus/1/answer`, () => {
           return HttpResponse.json(
             { message: "Conflict" },
             { status: 409 },


### PR DESCRIPTION
## 概要

back 側のエンドポイント移設（`POST /api/v1/user/sangakus/:id/answers` → `POST /api/v1/user/saved_sangakus/:id/answer`）に合わせて、front の呼び出し先を修正した。

対応 back PR: https://github.com/Alnoir-0011/algo_sangaku_back/pull/340

## 確認方法

1. `pnpm test:e2e "tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts" "tests/e2e/saved_sangakus/[id]/answer/page.spec.ts"` が通ることを確認
2. `pnpm lint` が通ることを確認
3. 算額の解答作成〜結果表示までのフローが問題なく動作すること

## 影響範囲

- `app/lib/actions/answer.ts`（`createAnswer`）: 呼び出し先URLの変更、リクエストボディを `{ answer: { source } }` の形で明示的にラップ
- `app/lib/data/answer.ts`（`fetchUserAnswer`, `fetchUserAnswerWithSangakuId`）: `createAnswer` と同水準の `isValidId` + `encodeURIComponent` によるID検証を追加（呼び出し先URL自体は変更なし）
- `tests/e2e/saved_sangakus/[id]/answer/create/page.spec.ts`: MSWモックのURLを新エンドポイントに追従

## チェックリスト

- [x] Lint のチェックをパスした
- [x] E2Eテストを更新した

## コメント

back 側でコントローラ名をリネームした際、Railsの `ParamsWrapper` の自動ラップキーが変わり、front が従来送っていたフラットなJSONボディ（`{"source": "..."}`）では `POST` が常に400になる回帰が一時発生しました。back側で `wrap_parameters` を明示する対応に加え、front側でも `answer` キーで明示的にラップする形に変更し、二重に安全側に倒しています。